### PR TITLE
leaderboard score submission screen

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,3 +1,5 @@
+package.path = './vendor/share/lua/5.1/?.lua;' .. package.path
+
 return {
     _all = {
         helper = './spec/helper.lua'

--- a/.github/workflows/leaderboard-python-tests.yml
+++ b/.github/workflows/leaderboard-python-tests.yml
@@ -6,8 +6,12 @@ name: Python application
 on:
   push:
     branches: [ "master" ]
+    paths:
+      - 'leaderboard/**'
   pull_request:
     branches: [ "master" ]
+    paths:
+      - 'leaderboard/**'
 
 permissions:
   contents: read

--- a/.github/workflows/lua-tests.yml
+++ b/.github/workflows/lua-tests.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Install busted
         run: luarocks install busted
 
+      - name: Install luasocket
+        run: luarocks install luasocket
+
       - name: Run tests
         run: busted spec

--- a/.github/workflows/lua-tests.yml
+++ b/.github/workflows/lua-tests.yml
@@ -2,8 +2,12 @@ name: Lua Unit Tests
 
 on:
   push:
+    paths:
+      - '**/*.lua'
   pull_request:
     branches: [master]
+    paths:
+      - '**/*.lua'
 
 jobs:
   test-lua:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ leaderboard/data
 .vscode
 .DS_STORE
 __pycache__
+/luarocks
+/lua
+/.luarocks

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,11 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
-    "runtime.special": {
-        "love.filesystem.load": "loadfile"
-    },
-    "workspace.library": [
-        "${3rd}/love2d/library",
-        "${3rd}/luassert/library",
-        "${3rd}/busted/library"
-    ]
+  "runtime.special": {
+    "love.filesystem.load": "loadfile"
+  },
+  "workspace.library": [
+    "${3rd}/love2d/library",
+    "${3rd}/luassert/library",
+    "${3rd}/busted/library",
+    "${workspaceFolder}/vendor"
+  ],
+  "runtime.path": [
+    "?.lua",
+    "?/init.lua",
+    "vendor/?.lua",
+    "vendor/?/init.lua",
+    "vendor/share/lua/5.1/?.lua"
+  ]
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "leaderboard_api": "http://localhost:8000"
+}

--- a/main.lua
+++ b/main.lua
@@ -8,7 +8,7 @@ local GameScene = require('scenes.game')
 local LoadingScreen = require('scenes.loadingScreen')
 local UpgradeScreen = require('scenes.upgradeScreen')
 local MainMenuScene = require('scenes.mainmenu')
-local UITestScene = require('scenes.uitest')
+local LeaderboardSubmitScene = require('scenes.leaderboardSubmit')
 
 local START_SCENE = os.getenv('ZPJ_START_SCREEN') or 'loading'
 
@@ -22,7 +22,7 @@ function love.load()
         loading = LoadingScreen:new(),
         upgrade = UpgradeScreen:new(),
         mainmenu = MainMenuScene:new(),
-        uitest = UITestScene:new(),
+        leaderboardsubmit = LeaderboardSubmitScene:new(),
     }
 
     local w = love.graphics.getWidth()

--- a/main.lua
+++ b/main.lua
@@ -3,6 +3,7 @@ package.path = './vendor/share/lua/5.1/?.lua;' .. package.path
 local Ui = require('util.ui')
 local fonts = require('util.fonts')
 local SceneManager = require('renderer.scenemanager')
+local config = require('util.config')
 
 local GameScene = require('scenes.game')
 local LoadingScreen = require('scenes.loadingScreen')
@@ -16,6 +17,8 @@ local START_SCENE = os.getenv('ZPJ_START_SCREEN') or 'loading'
 local scene_manager
 
 function love.load()
+    config:loadConfig('config.json')
+
     -- print("START SCENE", START_SCENE)
     scene_manager = SceneManager:new {
         game = GameScene:new(),

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,5 @@
+package.path = './vendor/share/lua/5.1/?.lua;' .. package.path
+
 local Ui = require('util.ui')
 local fonts = require('util.fonts')
 local SceneManager = require('renderer.scenemanager')

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,7 @@ local GameScene = require('scenes.game')
 local LoadingScreen = require('scenes.loadingScreen')
 local UpgradeScreen = require('scenes.upgradeScreen')
 local MainMenuScene = require('scenes.mainmenu')
+local UITestScene = require('scenes.uitest')
 
 local START_SCENE = os.getenv('ZPJ_START_SCREEN') or 'loading'
 
@@ -19,6 +20,7 @@ function love.load()
         loading = LoadingScreen:new(),
         upgrade = UpgradeScreen:new(),
         mainmenu = MainMenuScene:new(),
+        uitest = UITestScene:new(),
     }
 
     local w = love.graphics.getWidth()
@@ -66,4 +68,7 @@ function love.mousepressed(...)
 end
 function love.mousereleased(...)
     scene_manager:mousereleased(...)
+end
+function love.textinput(...)
+    scene_manager:textinput(...)
 end

--- a/player.lua
+++ b/player.lua
@@ -44,6 +44,9 @@ function Player.load(opts)
     Player.dx = 0
     Player.dy = 0
 
+    -- TODO: how does score work?
+    Player.score = 0
+
     -- Player.updateScale(scale)
     Player.showHitboxes = false
 

--- a/renderer/scenemanager.lua
+++ b/renderer/scenemanager.lua
@@ -11,6 +11,7 @@
 ---@field mousepressed fun(self: SceneManager, x: number, y: number, button: number, istouch: boolean, presses: number)
 ---@field mousereleased fun(self: SceneManager, x: number, y: number, button: number, istouch: boolean, presses: number)
 ---@field resize fun(self: SceneManager, w: number, h: number)
+---@field textinput fun(self: SceneManager, str: string)
 local SceneManager = {}
 SceneManager.__index = SceneManager
 
@@ -62,6 +63,7 @@ local love_callbacks = {
     'mousepressed',
     'mousereleased',
     'resize',
+    'textinput',
 }
 
 for _, name in ipairs(love_callbacks) do

--- a/scenes/leaderboardSubmit.lua
+++ b/scenes/leaderboardSubmit.lua
@@ -22,16 +22,16 @@ local function submitScore(name, score)
     }
     local responseBody = {}
 
-    http.request({
+    http.request {
         url = 'http://localhost:8000/score',
         method = 'POST',
         headers = {
             ['Content-Type'] = 'application/json',
-            ['Content-Length'] = tostring(#requestBody)
+            ['Content-Length'] = tostring(#requestBody),
         },
         source = ltn12.source.string(requestBody),
-        sink = ltn12.sink.table(responseBody)
-    })
+        sink = ltn12.sink.table(responseBody),
+    }
 end
 
 function LeaderboardSubmitScene:new()

--- a/scenes/leaderboardSubmit.lua
+++ b/scenes/leaderboardSubmit.lua
@@ -7,6 +7,7 @@ local ltn12 = require('ltn12')
 local json = require('JSON')
 local Player = require('player')
 local constants = require('util.constants')
+local config = require('util.config')
 
 ---@class LeaderboardSubmitScene : Scene
 local LeaderboardSubmitScene = {}
@@ -23,7 +24,7 @@ local function submitScore(name, score)
     local responseBody = {}
 
     http.request {
-        url = 'http://localhost:8000/score',
+        url = config.leaderboard_api .. '/score',
         method = 'POST',
         headers = {
             ['Content-Type'] = 'application/json',

--- a/scenes/leaderboardSubmit.lua
+++ b/scenes/leaderboardSubmit.lua
@@ -23,7 +23,7 @@ local function submitScore(name, score)
     }
     local responseBody = {}
 
-    http.request {
+    local body = http.request {
         url = config.leaderboard_api .. '/score',
         method = 'POST',
         headers = {
@@ -33,17 +33,24 @@ local function submitScore(name, score)
         source = ltn12.source.string(requestBody),
         sink = ltn12.sink.table(responseBody),
     }
+
+    return body ~= nil
 end
 
 function LeaderboardSubmitScene:new()
     local o = setmetatable({}, self)
     o.input = ''
     o.liveInput = ''
+    o.failed = false
+    o.waitTime = 0
     return o
 end
 
 function LeaderboardSubmitScene:enter()
     love.keyboard.setKeyRepeat(true)
+    self.failed = false
+    self.waitTime = 0
+
     self.textbox = UITextbox:new {
         width = 900,
         focused = true,
@@ -53,7 +60,12 @@ function LeaderboardSubmitScene:enter()
             tb.focused = false
             self.input = value
 
-            submitScore(value, Player.score)
+            local success = submitScore(value, Player.score)
+            if success then
+                self.scene_manager:transition('upgrade')
+            else
+                self.failed = true
+            end
         end,
 
         onInput = function(_, value)
@@ -71,6 +83,7 @@ function LeaderboardSubmitScene:draw()
 
     local titleFont = fonts.impact75
 
+    love.graphics.setColor(constants.colors.title)
     love.graphics.setFont(titleFont)
     love.graphics.printf(
         'Game Over',
@@ -100,6 +113,19 @@ function LeaderboardSubmitScene:draw()
 
     love.graphics.draw(tbcanvas, tbCenterX, tbCenterY)
 
+    if self.failed then
+        local errorFont = fonts.tahoma25
+        love.graphics.setColor(constants.colors.error)
+        love.graphics.setFont(errorFont)
+        love.graphics.printf(
+            'Failed to submit score to leaderboard',
+            0,
+            Ui:getHeight() * 0.375 + tbcanvas:getHeight() / 2,
+            Ui:getWidth(),
+            'center'
+        )
+    end
+
     -- TODO: switch to leaderboard scene
     -- TODO: only show this screen if score is in top 10?
 end
@@ -116,6 +142,16 @@ end
 
 function LeaderboardSubmitScene:update(dt)
     self.textbox:update(dt)
+
+    if not self.failed then
+        return
+    end
+
+    if self.waitTime >= 2.0 then
+        self.scene_manager:transition('upgrade')
+    else
+        self.waitTime = self.waitTime + dt
+    end
 end
 
 return LeaderboardSubmitScene

--- a/scenes/leaderboardSubmit.lua
+++ b/scenes/leaderboardSubmit.lua
@@ -6,11 +6,12 @@ local http = require('socket.http')
 local ltn12 = require('ltn12')
 local json = require('JSON')
 local Player = require('player')
+local constants = require('util.constants')
 
----@class UITestScene : Scene
-local UITestScene = {}
-setmetatable(UITestScene, { __index = Scene })
-UITestScene.__index = UITestScene
+---@class LeaderboardSubmitScene : Scene
+local LeaderboardSubmitScene = {}
+setmetatable(LeaderboardSubmitScene, { __index = Scene })
+LeaderboardSubmitScene.__index = LeaderboardSubmitScene
 
 ---@param name string
 ---@param score number
@@ -33,14 +34,14 @@ local function submitScore(name, score)
     })
 end
 
-function UITestScene:new()
+function LeaderboardSubmitScene:new()
     local o = setmetatable({}, self)
     o.input = ''
     o.liveInput = ''
     return o
 end
 
-function UITestScene:enter()
+function LeaderboardSubmitScene:enter()
     love.keyboard.setKeyRepeat(true)
     self.textbox = UITextbox:new {
         width = 900,
@@ -49,7 +50,6 @@ function UITestScene:enter()
         maxLength = 32,
         onSubmit = function(tb, value)
             tb.focused = false
-            print('submitted textbox:', value)
             self.input = value
 
             submitScore(value, Player.score)
@@ -61,12 +61,12 @@ function UITestScene:enter()
     }
 end
 
-function UITestScene:exit()
+function LeaderboardSubmitScene:exit()
     love.keyboard.setKeyRepeat(false)
 end
 
-function UITestScene:draw()
-    love.graphics.clear()
+function LeaderboardSubmitScene:draw()
+    love.graphics.clear(constants.colors.menu.bg)
 
     local titleFont = fonts.impact75
 
@@ -99,26 +99,22 @@ function UITestScene:draw()
 
     love.graphics.draw(tbcanvas, tbCenterX, tbCenterY)
 
-    local x = Ui:scaleDimension(20)
-    local gap = Ui:scaleDimension(50)
-    love.graphics.print('Input: ' .. self.liveInput, x, tbCenterY + gap * 2)
-    if #self.input ~= 0 then
-        love.graphics.print('You typed: ' .. self.input, x, tbCenterY + gap * 3)
-    end
+    -- TODO: switch to leaderboard scene
+    -- TODO: only show this screen if score is in top 10?
 end
 
 ---@param str string
-function UITestScene:textinput(str)
+function LeaderboardSubmitScene:textinput(str)
     self.textbox:textinput(str)
 end
 
 ---@param key string
-function UITestScene:keypressed(key)
+function LeaderboardSubmitScene:keypressed(key)
     self.textbox:keypressed(key)
 end
 
-function UITestScene:update(dt)
+function LeaderboardSubmitScene:update(dt)
     self.textbox:update(dt)
 end
 
-return UITestScene
+return LeaderboardSubmitScene

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -1,39 +1,57 @@
 local Scene = require('renderer.scene')
 local UITextbox = require('ui.textbox')
+local Ui = require('util.ui')
 
 ---@class UITestScene : Scene
----@field textbox UITextbox
 local UITestScene = {}
 setmetatable(UITestScene, {__index = Scene})
 UITestScene.__index = UITestScene
 
 function UITestScene:new()
     local o = setmetatable({}, self)
+    o.input = ""
+    o.liveInput = ""
     return o
 end
 
 function UITestScene:enter()
     self.textbox = UITextbox:new {
         width = 900,
+        focused = true,
+        placeholder = "enter your name",
+        onSubmit = function (tb, value)
+            tb.focused = false
+            print("submitted textbox:", value)
+            self.input = value
+        end,
+
+        onInput = function (tb, value)
+            self.liveInput = value
+        end
     }
 end
 
 function UITestScene:draw()
     love.graphics.clear()
-    love.graphics.draw(self.textbox:draw(), 20, 100)
+    local x, y = Ui:scaleCoord(20, 100)
+    love.graphics.draw(self.textbox:draw(), x, y)
+
+    x, y = Ui:scaleCoord(20, 150)
+    love.graphics.print("Input: " .. self.liveInput, x, y)
+    if #self.input then
+        x, y = Ui:scaleCoord(20, 200)
+        love.graphics.print("You typed: " .. self.input, x, y)
+    end
 end
 
 ---@param str string
 function UITestScene:textinput(str)
-    self.textbox.value = self.textbox.value .. str
+    self.textbox:textinput(str)
 end
 
 ---@param key string
 function UITestScene:keypressed(key)
-    if key == "backspace" then
-        self.textbox.value = self.textbox.value:sub(1, -2)
-        return
-    end
+    self.textbox:keypressed(key)
 end
 
 function UITestScene:update(dt)

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -2,11 +2,36 @@ local Scene = require('renderer.scene')
 local UITextbox = require('ui.textbox')
 local Ui = require('util.ui')
 local fonts = require('util.fonts')
+local http = require('socket.http')
+local ltn12 = require('ltn12')
+local json = require('JSON')
+local Player = require('player')
 
 ---@class UITestScene : Scene
 local UITestScene = {}
 setmetatable(UITestScene, { __index = Scene })
 UITestScene.__index = UITestScene
+
+---@param name string
+---@param score number
+local function submitScore(name, score)
+    local requestBody = json:encode {
+        name = name,
+        score = score,
+    }
+    local responseBody = {}
+
+    http.request({
+        url = 'http://localhost:8000/score',
+        method = 'POST',
+        headers = {
+            ['Content-Type'] = 'application/json',
+            ['Content-Length'] = tostring(#requestBody)
+        },
+        source = ltn12.source.string(requestBody),
+        sink = ltn12.sink.table(responseBody)
+    })
+end
 
 function UITestScene:new()
     local o = setmetatable({}, self)
@@ -26,6 +51,8 @@ function UITestScene:enter()
             tb.focused = false
             print('submitted textbox:', value)
             self.input = value
+
+            submitScore(value, Player.score)
         end,
 
         onInput = function(_, value)
@@ -55,7 +82,7 @@ function UITestScene:draw()
 
     love.graphics.setFont(fonts.impact50)
     love.graphics.printf(
-        'Score: 12345',
+        'Score: ' .. Player.score,
         0,
         math.floor(Ui:getHeight() * 0.25)
             - math.floor(titleFont:getHeight() / 2),

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -1,6 +1,7 @@
 local Scene = require('renderer.scene')
 local UITextbox = require('ui.textbox')
 local Ui = require('util.ui')
+local fonts = require('util.fonts')
 
 ---@class UITestScene : Scene
 local UITestScene = {}
@@ -15,10 +16,11 @@ function UITestScene:new()
 end
 
 function UITestScene:enter()
+    love.keyboard.setKeyRepeat(true)
     self.textbox = UITextbox:new {
         width = 900,
         focused = true,
-        placeholder = "enter your name",
+        placeholder = "Enter your name...",
         onSubmit = function (tb, value)
             tb.focused = false
             print("submitted textbox:", value)
@@ -31,16 +33,37 @@ function UITestScene:enter()
     }
 end
 
+function UITestScene:exit()
+    love.keyboard.setKeyRepeat(false)
+end
+
 function UITestScene:draw()
     love.graphics.clear()
-    local x, y = Ui:scaleCoord(20, 100)
-    love.graphics.draw(self.textbox:draw(), x, y)
 
-    x, y = Ui:scaleCoord(20, 150)
-    love.graphics.print("Input: " .. self.liveInput, x, y)
-    if #self.input then
-        x, y = Ui:scaleCoord(20, 200)
-        love.graphics.print("You typed: " .. self.input, x, y)
+    local titleFont = fonts.impact75
+
+    love.graphics.setFont(titleFont)
+    love.graphics.printf(
+        'Game Over',
+        0,
+        math.floor(Ui:getHeight() * 0.125) - math.floor(titleFont:getHeight() / 2),
+        Ui:getWidth(),
+        'center'
+    )
+
+    local tbcanvas = self.textbox:draw()
+    tbcanvas:getWidth()
+
+    local tbCenterX = Ui.centerX - math.floor(tbcanvas:getWidth() / 2)
+    local tbCenterY = math.floor((Ui:getHeight() * 0.25) - tbcanvas:getHeight() / 2)
+
+    love.graphics.draw(tbcanvas, tbCenterX, tbCenterY)
+
+    local x = Ui:scaleDimension(20)
+    local gap = Ui:scaleDimension(50)
+    love.graphics.print("Input: " .. self.liveInput, x, tbCenterY + gap*2)
+    if #self.input ~= 0 then
+        love.graphics.print("You typed: " .. self.input, x, tbCenterY + gap * 3)
     end
 end
 

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -1,0 +1,43 @@
+local Scene = require('renderer.scene')
+local UITextbox = require('ui.textbox')
+
+---@class UITestScene : Scene
+---@field textbox UITextbox
+local UITestScene = {}
+setmetatable(UITestScene, {__index = Scene})
+UITestScene.__index = UITestScene
+
+function UITestScene:new()
+    local o = setmetatable({}, self)
+    return o
+end
+
+function UITestScene:enter()
+    self.textbox = UITextbox:new {
+        width = 900,
+    }
+end
+
+function UITestScene:draw()
+    love.graphics.clear()
+    love.graphics.draw(self.textbox:draw(), 20, 100)
+end
+
+---@param str string
+function UITestScene:textinput(str)
+    self.textbox.value = self.textbox.value .. str
+end
+
+---@param key string
+function UITestScene:keypressed(key)
+    if key == "backspace" then
+        self.textbox.value = self.textbox.value:sub(1, -2)
+        return
+    end
+end
+
+function UITestScene:update(dt)
+    self.textbox:update(dt)
+end
+
+return UITestScene

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -5,13 +5,13 @@ local fonts = require('util.fonts')
 
 ---@class UITestScene : Scene
 local UITestScene = {}
-setmetatable(UITestScene, {__index = Scene})
+setmetatable(UITestScene, { __index = Scene })
 UITestScene.__index = UITestScene
 
 function UITestScene:new()
     local o = setmetatable({}, self)
-    o.input = ""
-    o.liveInput = ""
+    o.input = ''
+    o.liveInput = ''
     return o
 end
 
@@ -20,16 +20,17 @@ function UITestScene:enter()
     self.textbox = UITextbox:new {
         width = 900,
         focused = true,
-        placeholder = "Enter your name...",
-        onSubmit = function (tb, value)
+        placeholder = 'Enter your name for the leaderboard...',
+        maxLength = 32,
+        onSubmit = function(tb, value)
             tb.focused = false
-            print("submitted textbox:", value)
+            print('submitted textbox:', value)
             self.input = value
         end,
 
-        onInput = function (_, value)
+        onInput = function(_, value)
             self.liveInput = value
-        end
+        end,
     }
 end
 
@@ -46,7 +47,18 @@ function UITestScene:draw()
     love.graphics.printf(
         'Game Over',
         0,
-        math.floor(Ui:getHeight() * 0.125) - math.floor(titleFont:getHeight() / 2),
+        math.floor(Ui:getHeight() * 0.125)
+            - math.floor(titleFont:getHeight() / 2),
+        Ui:getWidth(),
+        'center'
+    )
+
+    love.graphics.setFont(fonts.impact50)
+    love.graphics.printf(
+        'Score: 12345',
+        0,
+        math.floor(Ui:getHeight() * 0.25)
+            - math.floor(titleFont:getHeight() / 2),
         Ui:getWidth(),
         'center'
     )
@@ -55,15 +67,16 @@ function UITestScene:draw()
     tbcanvas:getWidth()
 
     local tbCenterX = Ui.centerX - math.floor(tbcanvas:getWidth() / 2)
-    local tbCenterY = math.floor((Ui:getHeight() * 0.25) - tbcanvas:getHeight() / 2)
+    local tbCenterY =
+        math.floor((Ui:getHeight() * 0.375) - tbcanvas:getHeight() / 2)
 
     love.graphics.draw(tbcanvas, tbCenterX, tbCenterY)
 
     local x = Ui:scaleDimension(20)
     local gap = Ui:scaleDimension(50)
-    love.graphics.print("Input: " .. self.liveInput, x, tbCenterY + gap*2)
+    love.graphics.print('Input: ' .. self.liveInput, x, tbCenterY + gap * 2)
     if #self.input ~= 0 then
-        love.graphics.print("You typed: " .. self.input, x, tbCenterY + gap * 3)
+        love.graphics.print('You typed: ' .. self.input, x, tbCenterY + gap * 3)
     end
 end
 

--- a/scenes/uitest.lua
+++ b/scenes/uitest.lua
@@ -25,7 +25,7 @@ function UITestScene:enter()
             self.input = value
         end,
 
-        onInput = function (tb, value)
+        onInput = function (_, value)
             self.liveInput = value
         end
     }

--- a/spec/leaderboardsubmit_spec.lua
+++ b/spec/leaderboardsubmit_spec.lua
@@ -1,0 +1,51 @@
+local LeaderboardSubmitScene = require('scenes.leaderboardSubmit')
+
+describe('LeaderboardSubmitScene', function()
+    describe('new', function()
+        it('creates scene with empty input', function()
+            local scene = LeaderboardSubmitScene:new()
+            assert.are.equal('', scene.input)
+        end)
+
+        it('creates scene with empty liveInput', function()
+            local scene = LeaderboardSubmitScene:new()
+            assert.are.equal('', scene.liveInput)
+        end)
+    end)
+
+    describe('textinput', function()
+        it('delegates to textbox', function()
+            local scene = LeaderboardSubmitScene:new()
+            scene.textbox = {
+                textinput = function(self, str)
+                    assert.are.equal('a', str)
+                end,
+            }
+            scene:textinput('a')
+        end)
+    end)
+
+    describe('keypressed', function()
+        it('delegates to textbox', function()
+            local scene = LeaderboardSubmitScene:new()
+            scene.textbox = {
+                keypressed = function(self, key)
+                    assert.are.equal('return', key)
+                end,
+            }
+            scene:keypressed('return')
+        end)
+    end)
+
+    describe('update', function()
+        it('delegates to textbox', function()
+            local scene = LeaderboardSubmitScene:new()
+            scene.textbox = {
+                update = function(self, dt)
+                    assert.are.equal(0.016, dt)
+                end,
+            }
+            scene:update(0.016)
+        end)
+    end)
+end)

--- a/spec/textbox_spec.lua
+++ b/spec/textbox_spec.lua
@@ -1,0 +1,203 @@
+local UITextbox = require('ui.textbox')
+
+describe('UITextbox', function()
+    describe('new', function()
+        it('creates textbox with default values', function()
+            local textbox = UITextbox:new {}
+
+            assert.are.equal(0, textbox.x)
+            assert.are.equal(0, textbox.y)
+            assert.are.equal(0, textbox.width)
+            assert.are.equal(0, textbox.height)
+            assert.are.equal('', textbox.value)
+            assert.are.equal('', textbox.placeholder)
+            assert.is_nil(textbox.focused)
+            assert.are.equal(0.5, textbox.blinkRate)
+            assert.is_true(textbox.caretVisible)
+        end)
+
+        it('creates textbox with custom values', function()
+            local textbox = UITextbox:new {
+                x = 100,
+                y = 200,
+                width = 300,
+                height = 50,
+                value = 'test value',
+                focused = true,
+                placeholder = 'Enter name',
+                maxLength = 32,
+                blinkRate = 1,
+            }
+
+            assert.are.equal(100, textbox.x)
+            assert.are.equal(200, textbox.y)
+            assert.are.equal(300, textbox.width)
+            assert.are.equal(50, textbox.height)
+            assert.are.equal('test value', textbox.value)
+            assert.is_true(textbox.focused)
+            assert.are.equal('Enter name', textbox.placeholder)
+            assert.are.equal(32, textbox.maxLength)
+            assert.are.equal(1, textbox.blinkRate)
+        end)
+
+        it('sets default blinkRate', function()
+            local textbox = UITextbox:new {}
+            assert.are.equal(0.5, textbox.blinkRate)
+        end)
+
+        it('sets default blinkRate when provided', function()
+            local textbox = UITextbox:new { blinkRate = 2 }
+            assert.are.equal(2, textbox.blinkRate)
+        end)
+
+        it('sets default maxLength to 0', function()
+            local textbox = UITextbox:new {}
+            assert.are.equal(0, textbox.maxLength)
+        end)
+
+        it('sets onInput to empty function by default', function()
+            local textbox = UITextbox:new {}
+            assert.is_function(textbox.onInput)
+        end)
+    end)
+
+    describe('update', function()
+        it('hides caret when not focused', function()
+            local textbox = UITextbox:new { focused = false }
+            textbox.caretVisible = true
+            textbox:update(0.016)
+            assert.is_false(textbox.caretVisible)
+        end)
+
+        it('does not update blink when blinkRate is 0', function()
+            local textbox = UITextbox:new { focused = true, blinkRate = 0 }
+            textbox.caretVisible = true
+            textbox:update(1)
+            assert.is_true(textbox.caretVisible)
+        end)
+
+        it('toggles caret visibility on blink cycle', function()
+            local textbox = UITextbox:new { focused = true, blinkRate = 0.5 }
+            textbox.caretVisible = true
+            textbox.blinkTime = 0
+            textbox:update(0.5)
+            assert.is_false(textbox.caretVisible)
+            assert.are.equal(0, textbox.blinkTime)
+        end)
+
+        it('resets blinkTime after toggle', function()
+            local textbox = UITextbox:new { focused = true, blinkRate = 0.5 }
+            textbox.caretVisible = true
+            textbox.blinkTime = 0.25
+            textbox:update(0.5)
+            assert.are.equal(0, textbox.blinkTime)
+        end)
+
+        it('does not toggle if blinkTime is less than blinkRate', function()
+            local textbox = UITextbox:new { focused = true, blinkRate = 0.5 }
+            textbox.caretVisible = true
+            textbox.blinkTime = 0.3
+            textbox:update(0.1)
+            assert.is_true(textbox.caretVisible)
+        end)
+    end)
+
+    describe('keypressed', function()
+        it('does nothing when not focused', function()
+            local textbox = UITextbox:new { focused = false }
+            textbox.value = 'test'
+            textbox:keypressed('backspace')
+            assert.are.equal('test', textbox.value)
+        end)
+
+        it('removes last character on backspace', function()
+            local textbox = UITextbox:new { focused = true }
+            textbox.value = 'test'
+            textbox:keypressed('backspace')
+            assert.are.equal('tes', textbox.value)
+        end)
+
+        it('calls onSubmit with value on return', function()
+            local submittedValue = nil
+            local textbox = UITextbox:new {
+                focused = true,
+                value = 'player1',
+                onSubmit = function(self, value)
+                    submittedValue = value
+                end,
+            }
+            textbox:keypressed('return')
+            assert.are.equal('player1', submittedValue)
+        end)
+
+        it('does not submit empty value', function()
+            local submitted = false
+            local textbox = UITextbox:new {
+                focused = true,
+                value = '',
+                onSubmit = function(self, value)
+                    submitted = true
+                end,
+            }
+            textbox:keypressed('return')
+            assert.is_false(submitted)
+        end)
+
+        it('ignores other keys', function()
+            local textbox = UITextbox:new { focused = true }
+            textbox.value = 'test'
+            textbox:keypressed('a')
+            assert.are.equal('test', textbox.value)
+        end)
+    end)
+
+    describe('textinput', function()
+        it('does nothing when not focused', function()
+            local textbox = UITextbox:new { focused = false }
+            textbox.value = 'test'
+            textbox:textinput('a')
+            assert.are.equal('test', textbox.value)
+        end)
+
+        it('appends text when focused', function()
+            local textbox = UITextbox:new { focused = true }
+            textbox:textinput('a')
+            assert.are.equal('a', textbox.value)
+        end)
+
+        it('respects maxLength limit', function()
+            local textbox = UITextbox:new { focused = true, maxLength = 3 }
+            textbox.value = 'ab'
+            textbox:textinput('c')
+            assert.are.equal('abc', textbox.value)
+            textbox:textinput('d')
+            assert.are.equal('abcd', textbox.value)
+        end)
+
+        it('does not append when at maxLength', function()
+            local textbox = UITextbox:new { focused = true, maxLength = 3 }
+            textbox.value = 'abc'
+            textbox:textinput('d')
+            assert.are.equal('abcd', textbox.value)
+        end)
+
+        it('calls onInput after adding text', function()
+            local inputValue = nil
+            local textbox = UITextbox:new {
+                focused = true,
+                onInput = function(self, value)
+                    inputValue = value
+                end,
+            }
+            textbox:textinput('a')
+            assert.are.equal('a', inputValue)
+        end)
+
+        it('allows unlimited input when maxLength is 0', function()
+            local textbox = UITextbox:new { focused = true, maxLength = 0 }
+            local longString = string.rep('a', 100)
+            textbox:textinput(longString)
+            assert.are.equal(100, #textbox.value)
+        end)
+    end)
+end)

--- a/ui/element.lua
+++ b/ui/element.lua
@@ -54,6 +54,7 @@ function BaseUIElement:isWithin(x, y)
 end
 
 ---@param dt integer
-function BaseUIElement:update(dt) end
+function BaseUIElement:update(dt)
+end
 
 return BaseUIElement

--- a/ui/element.lua
+++ b/ui/element.lua
@@ -54,7 +54,6 @@ function BaseUIElement:isWithin(x, y)
 end
 
 ---@param dt integer
-function BaseUIElement:update(dt)
-end
+function BaseUIElement:update(dt) end
 
 return BaseUIElement

--- a/ui/textbox.lua
+++ b/ui/textbox.lua
@@ -1,0 +1,96 @@
+local BaseUIElement = require('ui.element')
+local Ui = require('util.ui')
+local constants = require('util.constants')
+local fonts = require('util.fonts')
+
+---@class UITextbox : BaseUIElement
+---@field value string
+---@field focused boolean
+---@field blinkRate number frequency of blink cycle
+---@field blinkTime number elapsed time since blink cycle started
+---@field caretVisible boolean
+local UITextbox = {}
+setmetatable(UITextbox, {__index = BaseUIElement})
+UITextbox.__index = UITextbox
+
+---@class UITextboxOptions : BaseUIElementOptions
+---@field height? integer
+---@field value? string
+---@field focused? boolean
+---@field blinkRate? number frequency of cursor blink (hz)
+
+---@param opts UITextboxOptions
+function UITextbox:new(opts)
+    local o = setmetatable({}, self)
+
+    o.x = opts.x or 0
+    o.y = opts.y or 0
+
+    o.width = opts.width or 0
+    o.height = opts.height or 0
+    o.blinkRate = opts.blinkRate or 0.5
+    o.blinkTime = 0
+    o.caretVisible = true
+
+    o.value = opts.value or ""
+
+    return o
+end
+
+function UITextbox:draw()
+    local padding = Ui:scaleDimension(4)
+    local font = fonts.tahoma40
+
+    local height = font:getHeight() + 2 * padding
+    local width = Ui:scaleDimension(self.width)
+    local maxTextWidth = width - 2 * padding
+    local canvas = love.graphics.newCanvas(width, height)
+
+    canvas:renderTo(function ()
+        love.graphics.clear(constants.colors.textbox.bg)
+
+        local fullTextWidth = font:getWidth(self.value)
+        local caretSpacing = Ui:scaleDimension(2)
+        local caretWidth = Ui:scaleDimension(4)
+
+        local textWidth, wrapped = font:getWrap(self.value:reverse(), maxTextWidth)
+        local str = wrapped[1]:reverse()
+
+        love.graphics.setFont(font)
+        love.graphics.setColor(0x00, 0x00, 0xff)
+        love.graphics.printf(
+            str,
+            padding,
+            (math.floor(height / 2) - math.floor(font:getHeight() / 2)),
+            width - padding * 2,
+            fullTextWidth >= maxTextWidth and 'right' or 'left'
+        )
+
+        if self.caretVisible or self.blinkRate == 0 then
+            love.graphics.setColor(constants.colors.textbox.caret)
+            love.graphics.rectangle(
+                'fill',
+                padding + textWidth + caretSpacing,
+                padding,
+                caretWidth,
+                font:getHeight()
+            )
+        end
+
+        love.graphics.setColor(constants.colors.textbox.bg)
+    end)
+
+    return canvas
+end
+
+function UITextbox:update(dt)
+    if self.blinkRate ~= 0 then
+        self.blinkTime = self.blinkTime + dt
+        if self.blinkTime >= self.blinkRate then
+            self.caretVisible = not self.caretVisible
+            self.blinkTime = 0
+        end
+    end
+end
+
+return UITextbox

--- a/ui/textbox.lua
+++ b/ui/textbox.lua
@@ -9,6 +9,9 @@ local fonts = require('util.fonts')
 ---@field blinkRate number frequency of blink cycle
 ---@field blinkTime number elapsed time since blink cycle started
 ---@field caretVisible boolean
+---@field onSubmit fun(self: UITextbox, value: string)
+---@field onInput fun(self: UITextbox, value: string)
+---@field placeholder string
 local UITextbox = {}
 setmetatable(UITextbox, {__index = BaseUIElement})
 UITextbox.__index = UITextbox
@@ -18,6 +21,9 @@ UITextbox.__index = UITextbox
 ---@field value? string
 ---@field focused? boolean
 ---@field blinkRate? number frequency of cursor blink (hz)
+---@field onSubmit fun(self: UITextbox, value: string)
+---@field onInput? fun(self: UITextbox, value: string)
+---@field placeholder? string
 
 ---@param opts UITextboxOptions
 function UITextbox:new(opts)
@@ -33,6 +39,11 @@ function UITextbox:new(opts)
     o.caretVisible = true
 
     o.value = opts.value or ""
+    o.onSubmit = opts.onSubmit
+    o.focused = opts.focused
+    o.placeholder = opts.placeholder or ""
+
+    o.onInput = opts.onInput or function() end
 
     return o
 end
@@ -57,9 +68,13 @@ function UITextbox:draw()
         local str = wrapped[1]:reverse()
 
         love.graphics.setFont(font)
-        love.graphics.setColor(0x00, 0x00, 0xff)
+        love.graphics.setColor(
+            #self.value == 0
+                and constants.colors.textbox.placeholder
+                or constants.colors.textbox.caret
+        )
         love.graphics.printf(
-            str,
+            #self.value == 0 and self.placeholder or str,
             padding,
             (math.floor(height / 2) - math.floor(font:getHeight() / 2)),
             width - padding * 2,
@@ -84,12 +99,40 @@ function UITextbox:draw()
 end
 
 function UITextbox:update(dt)
+    if not self.focused then
+        self.caretVisible = false
+        return
+    end
+
     if self.blinkRate ~= 0 then
         self.blinkTime = self.blinkTime + dt
         if self.blinkTime >= self.blinkRate then
             self.caretVisible = not self.caretVisible
             self.blinkTime = 0
         end
+    end
+end
+
+function UITextbox:keypressed(key)
+    if not self.focused then
+        return
+    end
+
+    if key == "backspace" then
+        self.value = self.value:sub(1, -2)
+    elseif key == "return" then
+        self:onSubmit(self.value)
+    else
+        return
+    end
+
+    self:onInput(self.value)
+end
+
+function UITextbox:textinput(str)
+    if self.focused then
+        self.value = self.value .. str
+        self:onInput(self.value)
     end
 end
 

--- a/ui/textbox.lua
+++ b/ui/textbox.lua
@@ -124,7 +124,9 @@ function UITextbox:keypressed(key)
     if key == 'backspace' then
         self.value = self.value:sub(1, -2)
     elseif key == 'return' then
-        self:onSubmit(self.value)
+        if #self.value > 0 then
+            self:onSubmit(self.value)
+        end
     else
         return
     end

--- a/ui/textbox.lua
+++ b/ui/textbox.lua
@@ -12,8 +12,9 @@ local fonts = require('util.fonts')
 ---@field onSubmit fun(self: UITextbox, value: string)
 ---@field onInput fun(self: UITextbox, value: string)
 ---@field placeholder string
+---@field maxLength number
 local UITextbox = {}
-setmetatable(UITextbox, {__index = BaseUIElement})
+setmetatable(UITextbox, { __index = BaseUIElement })
 UITextbox.__index = UITextbox
 
 ---@class UITextboxOptions : BaseUIElementOptions
@@ -24,6 +25,7 @@ UITextbox.__index = UITextbox
 ---@field onSubmit fun(self: UITextbox, value: string)
 ---@field onInput? fun(self: UITextbox, value: string)
 ---@field placeholder? string
+---@field maxLength? number
 
 ---@param opts UITextboxOptions
 function UITextbox:new(opts)
@@ -38,12 +40,13 @@ function UITextbox:new(opts)
     o.blinkTime = 0
     o.caretVisible = true
 
-    o.value = opts.value or ""
+    o.value = opts.value or ''
     o.onSubmit = opts.onSubmit
     o.focused = opts.focused
-    o.placeholder = opts.placeholder or ""
+    o.placeholder = opts.placeholder or ''
 
     o.onInput = opts.onInput or function() end
+    o.maxLength = opts.maxLength or 0
 
     return o
 end
@@ -57,20 +60,20 @@ function UITextbox:draw()
     local maxTextWidth = width - 2 * padding
     local canvas = love.graphics.newCanvas(width, height)
 
-    canvas:renderTo(function ()
+    canvas:renderTo(function()
         love.graphics.clear(constants.colors.textbox.bg)
 
         local fullTextWidth = font:getWidth(self.value)
         local caretSpacing = Ui:scaleDimension(2)
         local caretWidth = Ui:scaleDimension(4)
 
-        local textWidth, wrapped = font:getWrap(self.value:reverse(), maxTextWidth)
+        local textWidth, wrapped =
+            font:getWrap(self.value:reverse(), maxTextWidth)
         local str = wrapped[1]:reverse()
 
         love.graphics.setFont(font)
         love.graphics.setColor(
-            #self.value == 0
-                and constants.colors.textbox.placeholder
+            #self.value == 0 and constants.colors.textbox.placeholder
                 or constants.colors.textbox.caret
         )
         love.graphics.printf(
@@ -118,9 +121,9 @@ function UITextbox:keypressed(key)
         return
     end
 
-    if key == "backspace" then
+    if key == 'backspace' then
         self.value = self.value:sub(1, -2)
-    elseif key == "return" then
+    elseif key == 'return' then
         self:onSubmit(self.value)
     else
         return
@@ -131,8 +134,10 @@ end
 
 function UITextbox:textinput(str)
     if self.focused then
-        self.value = self.value .. str
-        self:onInput(self.value)
+        if #self.value <= self.maxLength then
+            self.value = self.value .. str
+            self:onInput(self.value)
+        end
     end
 end
 

--- a/util/config.lua
+++ b/util/config.lua
@@ -1,0 +1,24 @@
+local json = require('JSON')
+
+---@class GameConfig
+---@field leaderboard_api string
+local config = {}
+
+---@param path string
+function config:loadConfig(path)
+    local ok, file = pcall(love.filesystem.read, 'string', path)
+    if not ok or not file or #file == 0 then
+        print('failed to load config file. using defaults')
+        -- defaults if the config file can't be loaded
+        file = [[
+            {
+                "leaderboard_api": "http://localhost:8000"
+            }
+        ]]
+    end
+
+    local conf = json:decode(file)
+    self.leaderboard_api = conf.leaderboard_api
+end
+
+return config

--- a/util/constants.lua
+++ b/util/constants.lua
@@ -13,6 +13,7 @@ return {
         textbox = {
             bg = c.hex(0xFFFFFF),
             caret = c.hex(0x212121),
+            placeholder = c.hex(0x8c8c8c),
         },
     },
 }

--- a/util/constants.lua
+++ b/util/constants.lua
@@ -9,5 +9,10 @@ return {
             button_stroke_hover = c.hex(0xF39B64),
             button_fill = c.hex(0xFFFFFF),
         },
+
+        textbox = {
+            bg = c.hex(0xFFFFFF),
+            caret = c.hex(0x212121),
+        },
     },
 }

--- a/util/constants.lua
+++ b/util/constants.lua
@@ -15,5 +15,8 @@ return {
             caret = c.hex(0x212121),
             placeholder = c.hex(0x8c8c8c),
         },
+
+        title = c.hex(0xFFFFFF),
+        error = c.hex(0xF53D3D),
     },
 }

--- a/util/fonts.lua
+++ b/util/fonts.lua
@@ -11,6 +11,7 @@ function fonts:reload()
     self.impact75 = love.graphics.newFont('assets/fonts/impact.ttf', 75 * scale)
     self.tahoma30 = love.graphics.newFont('assets/fonts/tahoma.ttf', 30 * scale)
     self.tahoma14 = love.graphics.newFont('assets/fonts/tahoma.ttf', 14 * scale)
+    self.tahoma40 = love.graphics.newFont('assets/fonts/tahoma.ttf', 40 * scale)
 end
 
 return fonts

--- a/util/fonts.lua
+++ b/util/fonts.lua
@@ -9,6 +9,7 @@ local fonts = {}
 function fonts:reload()
     local scale = Ui:getScale()
     self.impact75 = love.graphics.newFont('assets/fonts/impact.ttf', 75 * scale)
+    self.impact50 = love.graphics.newFont('assets/fonts/impact.ttf', 50 * scale)
     self.tahoma30 = love.graphics.newFont('assets/fonts/tahoma.ttf', 30 * scale)
     self.tahoma14 = love.graphics.newFont('assets/fonts/tahoma.ttf', 14 * scale)
     self.tahoma40 = love.graphics.newFont('assets/fonts/tahoma.ttf', 40 * scale)

--- a/util/fonts.lua
+++ b/util/fonts.lua
@@ -12,6 +12,8 @@ function fonts:reload()
     self.impact50 = love.graphics.newFont('assets/fonts/impact.ttf', 50 * scale)
     self.tahoma30 = love.graphics.newFont('assets/fonts/tahoma.ttf', 30 * scale)
     self.tahoma14 = love.graphics.newFont('assets/fonts/tahoma.ttf', 14 * scale)
+    self.tahoma14 = love.graphics.newFont('assets/fonts/tahoma.ttf', 14 * scale)
+    self.tahoma25 = love.graphics.newFont('assets/fonts/tahoma.ttf', 25 * scale)
     self.tahoma40 = love.graphics.newFont('assets/fonts/tahoma.ttf', 40 * scale)
 end
 

--- a/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/doc/README.md
+++ b/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/doc/README.md
@@ -1,0 +1,74 @@
+
+JSON.lua
+----
+
+This project was originally created by Jeffrey Friedl: http://regex.info/blog/lua/json
+
+This repo is forked for LuaRocks.
+
+### Usage
+
+By running Luarocks you will actually get a `/usr/local/share/lua/5.2/JSON.lua`.
+
+```
+luarocks install json-lua
+```
+
+And then you may import code like this:
+
+```lua
+JSON = require("JSON")
+inspect = require("inspect")
+
+local raw_json_text = "[1,2,[3,4]]"
+
+local lua_value = JSON:decode(raw_json_text) -- decode example
+local raw_json_text    = JSON:encode(lua_value)        -- encode example
+local pretty_json_text = JSON:encode_pretty(lua_value) -- "pretty printed" version
+
+print(inspect(lua_value))
+print(inspect(raw_json_text))
+print(inspect(pretty_json_text))
+```
+
+Output:
+
+```kua
+{ 1, 2, { 3, 4 } }
+"[1,2,[3,4]]"
+"[ 1, 2, [ 3, 4 ] ]"
+```
+
+Notice that `encode_pretty` is not indented style. And it's a bug need to be fixed.
+
+### array_newline option
+
+```lua
+local pretty_json_text = JSON:encode_pretty(lua_value, nil, 
+           { pretty = true, align_keys = false, array_newline = true, indent = "|   " })
+print(pretty_json_text)
+```
+
+Output:
+
+```kua
+[
+|   1,
+|   2,
+|   [
+|   |   3,
+|   |   4
+|   ]
+]
+```
+ 
+
+### Test
+
+```
+lua test.lua
+```
+
+### License
+
+http://creativecommons.org/licenses/by/3.0/deed.en_US

--- a/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/json-lua-0.1-4.rockspec
+++ b/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/json-lua-0.1-4.rockspec
@@ -1,0 +1,23 @@
+
+package = "json-lua"
+version = "0.1-4"
+source = {
+  url = "git+https://github.com/tiye/json-lua.git"
+}
+description = {
+  summary = "JSON encoder/decoder",
+  detailed = [[
+    Forked from JSON.lua
+  ]],
+  homepage = "https://github.com/tiye/json-lua",
+  license = "CC"
+}
+dependencies = {
+  "lua >= 5.1"
+}
+build = {
+  type = "builtin",
+  modules = {
+    JSON = "JSON.lua"
+  }
+}

--- a/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/rock_manifest
+++ b/vendor/lib/luarocks/rocks-5.1/json-lua/0.1-4/rock_manifest
@@ -1,0 +1,9 @@
+rock_manifest = {
+   doc = {
+      ["README.md"] = "8f7f20297443eebff72985e6b623181a"
+   },
+   ["json-lua-0.1-4.rockspec"] = "7b82d1b5859b4cf55c03f3bb87c405a6",
+   lua = {
+      ["JSON.lua"] = "9cea93d1d0c4422198d7f71aa9f9c633"
+   }
+}

--- a/vendor/lib/luarocks/rocks-5.1/manifest
+++ b/vendor/lib/luarocks/rocks-5.1/manifest
@@ -1,0 +1,37 @@
+commands = {}
+dependencies = {
+   ["json-lua"] = {
+      ["0.1-4"] = {
+         {
+            constraints = {
+               {
+                  op = ">=",
+                  version = {
+                     5, 1, string = "5.1"
+                  }
+               }
+            },
+            name = "lua"
+         }
+      }
+   }
+}
+modules = {
+   JSON = {
+      "json-lua/0.1-4"
+   }
+}
+repository = {
+   ["json-lua"] = {
+      ["0.1-4"] = {
+         {
+            arch = "installed",
+            commands = {},
+            dependencies = {},
+            modules = {
+               JSON = "JSON.lua"
+            }
+         }
+      }
+   }
+}

--- a/vendor/share/lua/5.1/JSON.lua
+++ b/vendor/share/lua/5.1/JSON.lua
@@ -1,0 +1,1559 @@
+-- -*- coding: utf-8 -*-
+--
+-- Simple JSON encoding and decoding in pure Lua.
+--
+-- Copyright 2010-2016 Jeffrey Friedl
+-- http://regex.info/blog/
+-- Latest version: http://regex.info/blog/lua/json
+--
+-- This code is released under a Creative Commons CC-BY "Attribution" License:
+-- http://creativecommons.org/licenses/by/3.0/deed.en_US
+--
+-- It can be used for any purpose so long as:
+--    1) the copyright notice above is maintained
+--    2) the web-page links above are maintained
+--    3) the 'AUTHOR_NOTE' string below is maintained
+--
+local VERSION = '20161109.21' -- version history at end of file
+local AUTHOR_NOTE = "-[ JSON.lua package by Jeffrey Friedl (http://regex.info/blog/lua/json) version 20161109.21 ]-"
+
+--
+-- The 'AUTHOR_NOTE' variable exists so that information about the source
+-- of the package is maintained even in compiled versions. It's also
+-- included in OBJDEF below mostly to quiet warnings about unused variables.
+--
+local OBJDEF = {
+   VERSION      = VERSION,
+   AUTHOR_NOTE  = AUTHOR_NOTE,
+}
+
+
+--
+-- Simple JSON encoding and decoding in pure Lua.
+-- JSON definition: http://www.json.org/
+--
+--
+--   JSON = assert(loadfile "JSON.lua")() -- one-time load of the routines
+--
+--   local lua_value = JSON:decode(raw_json_text)
+--
+--   local raw_json_text    = JSON:encode(lua_table_or_value)
+--   local pretty_json_text = JSON:encode_pretty(lua_table_or_value) -- "pretty printed" version for human readability
+--
+--
+--
+-- DECODING (from a JSON string to a Lua table)
+--
+--
+--   JSON = assert(loadfile "JSON.lua")() -- one-time load of the routines
+--
+--   local lua_value = JSON:decode(raw_json_text)
+--
+--   If the JSON text is for an object or an array, e.g.
+--     { "what": "books", "count": 3 }
+--   or
+--     [ "Larry", "Curly", "Moe" ]
+--
+--   the result is a Lua table, e.g.
+--     { what = "books", count = 3 }
+--   or
+--     { "Larry", "Curly", "Moe" }
+--
+--
+--   The encode and decode routines accept an optional second argument,
+--   "etc", which is not used during encoding or decoding, but upon error
+--   is passed along to error handlers. It can be of any type (including nil).
+--
+--
+--
+-- ERROR HANDLING
+--
+--   With most errors during decoding, this code calls
+--
+--      JSON:onDecodeError(message, text, location, etc)
+--
+--   with a message about the error, and if known, the JSON text being
+--   parsed and the byte count where the problem was discovered. You can
+--   replace the default JSON:onDecodeError() with your own function.
+--
+--   The default onDecodeError() merely augments the message with data
+--   about the text and the location if known (and if a second 'etc'
+--   argument had been provided to decode(), its value is tacked onto the
+--   message as well), and then calls JSON.assert(), which itself defaults
+--   to Lua's built-in assert(), and can also be overridden.
+--
+--   For example, in an Adobe Lightroom plugin, you might use something like
+--
+--          function JSON:onDecodeError(message, text, location, etc)
+--             LrErrors.throwUserError("Internal Error: invalid JSON data")
+--          end
+--
+--   or even just
+--
+--          function JSON.assert(message)
+--             LrErrors.throwUserError("Internal Error: " .. message)
+--          end
+--
+--   If JSON:decode() is passed a nil, this is called instead:
+--
+--      JSON:onDecodeOfNilError(message, nil, nil, etc)
+--
+--   and if JSON:decode() is passed HTML instead of JSON, this is called:
+--
+--      JSON:onDecodeOfHTMLError(message, text, nil, etc)
+--
+--   The use of the fourth 'etc' argument allows stronger coordination
+--   between decoding and error reporting, especially when you provide your
+--   own error-handling routines. Continuing with the the Adobe Lightroom
+--   plugin example:
+--
+--          function JSON:onDecodeError(message, text, location, etc)
+--             local note = "Internal Error: invalid JSON data"
+--             if type(etc) = 'table' and etc.photo then
+--                note = note .. " while processing for " .. etc.photo:getFormattedMetadata('fileName')
+--             end
+--             LrErrors.throwUserError(note)
+--          end
+--
+--            :
+--            :
+--
+--          for i, photo in ipairs(photosToProcess) do
+--               :             
+--               :             
+--               local data = JSON:decode(someJsonText, { photo = photo })
+--               :             
+--               :             
+--          end
+--
+--
+--
+--   If the JSON text passed to decode() has trailing garbage (e.g. as with the JSON "[123]xyzzy"),
+--   the method
+--
+--       JSON:onTrailingGarbage(json_text, location, parsed_value, etc)
+--
+--   is invoked, where:
+--
+--       json_text is the original JSON text being parsed,
+--       location is the count of bytes into json_text where the garbage starts (6 in the example),
+--       parsed_value is the Lua result of what was successfully parsed ({123} in the example),
+--       etc is as above.
+--
+--   If JSON:onTrailingGarbage() does not abort, it should return the value decode() should return,
+--   or nil + an error message.
+--
+--     local new_value, error_message = JSON:onTrailingGarbage()
+--
+--   The default handler just invokes JSON:onDecodeError("trailing garbage"...), but you can have
+--   this package ignore trailing garbage via
+--
+--      function JSON:onTrailingGarbage(json_text, location, parsed_value, etc)
+--         return parsed_value
+--      end
+--
+--
+-- DECODING AND STRICT TYPES
+--
+--   Because both JSON objects and JSON arrays are converted to Lua tables,
+--   it's not normally possible to tell which original JSON type a
+--   particular Lua table was derived from, or guarantee decode-encode
+--   round-trip equivalency.
+--
+--   However, if you enable strictTypes, e.g.
+--
+--      JSON = assert(loadfile "JSON.lua")() --load the routines
+--      JSON.strictTypes = true
+--
+--   then the Lua table resulting from the decoding of a JSON object or
+--   JSON array is marked via Lua metatable, so that when re-encoded with
+--   JSON:encode() it ends up as the appropriate JSON type.
+--
+--   (This is not the default because other routines may not work well with
+--   tables that have a metatable set, for example, Lightroom API calls.)
+--
+--
+-- ENCODING (from a lua table to a JSON string)
+--
+--   JSON = assert(loadfile "JSON.lua")() -- one-time load of the routines
+--
+--   local raw_json_text    = JSON:encode(lua_table_or_value)
+--   local pretty_json_text = JSON:encode_pretty(lua_table_or_value) -- "pretty printed" version for human readability
+--   local custom_pretty    = JSON:encode(lua_table_or_value, etc, { pretty = true, indent = "|  ", align_keys = false })
+--
+--   On error during encoding, this code calls:
+--
+--     JSON:onEncodeError(message, etc)
+--
+--   which you can override in your local JSON object.
+--
+--   The 'etc' in the error call is the second argument to encode()
+--   and encode_pretty(), or nil if it wasn't provided.
+--
+--
+-- ENCODING OPTIONS
+--
+--   An optional third argument, a table of options, can be provided to encode().
+--
+--       encode_options =  {
+--           -- options for making "pretty" human-readable JSON (see "PRETTY-PRINTING" below)
+--           pretty         = true,
+--           indent         = "   ",
+--           align_keys     = false,
+--           array_newline  = false,
+--  
+--           -- other output-related options
+--           null           = "\0",   -- see "ENCODING JSON NULL VALUES" below
+--           stringsAreUtf8 = false,  -- see "HANDLING UNICODE LINE AND PARAGRAPH SEPARATORS FOR JAVA" below
+--       }
+--  
+--       json_string = JSON:encode(mytable, etc, encode_options)
+--
+--
+--
+-- For reference, the defaults are:
+--
+--           pretty         = false
+--           null           = nil,
+--           stringsAreUtf8 = false,
+--           array_newline  = false,
+--
+--
+--
+-- PRETTY-PRINTING
+--
+--   Enabling the 'pretty' encode option helps generate human-readable JSON.
+--
+--     pretty = JSON:encode(val, etc, {
+--                                       pretty = true,
+--                                       indent = "   ",
+--                                       align_keys = false,
+--                                     })
+--
+--   encode_pretty() is also provided: it's identical to encode() except
+--   that encode_pretty() provides a default options table if none given in the call:
+--
+--       { pretty = true, align_keys = false, indent = "  " }
+--
+--   For example, if
+--
+--      JSON:encode(data)
+--
+--   produces:
+--
+--      {"city":"Kyoto","climate":{"avg_temp":16,"humidity":"high","snowfall":"minimal"},"country":"Japan","wards":11}
+--
+--   then
+--
+--      JSON:encode_pretty(data)
+--
+--   produces:
+--
+--      {
+--        "city": "Kyoto",
+--        "climate": {
+--          "avg_temp": 16,
+--          "humidity": "high",
+--          "snowfall": "minimal"
+--        },
+--        "country": "Japan",
+--        "wards": 11
+--      }
+--
+--   The following three lines return identical results:
+--       JSON:encode_pretty(data)
+--       JSON:encode_pretty(data, nil, { pretty = true, align_keys = false, indent = "  " })
+--       JSON:encode       (data, nil, { pretty = true, align_keys = false, indent = "  " })
+--
+--   An example of setting your own indent string:
+--
+--     JSON:encode_pretty(data, nil, { pretty = true, indent = "|    " })
+--
+--   produces:
+--
+--      {
+--      |    "city": "Kyoto",
+--      |    "climate": {
+--      |    |    "avg_temp": 16,
+--      |    |    "humidity": "high",
+--      |    |    "snowfall": "minimal"
+--      |    },
+--      |    "country": "Japan",
+--      |    "wards": 11
+--      }
+--
+--   An example of setting align_keys to true:
+--
+--     JSON:encode_pretty(data, nil, { pretty = true, indent = "  ", align_keys = true })
+--  
+--   produces:
+--   
+--      {
+--           "city": "Kyoto",
+--        "climate": {
+--                     "avg_temp": 16,
+--                     "humidity": "high",
+--                     "snowfall": "minimal"
+--                   },
+--        "country": "Japan",
+--          "wards": 11
+--      }
+--
+--   which I must admit is kinda ugly, sorry. This was the default for
+--   encode_pretty() prior to version 20141223.14.
+--
+--
+--  HANDLING UNICODE LINE AND PARAGRAPH SEPARATORS FOR JAVA
+--
+--    If the 'stringsAreUtf8' encode option is set to true, consider Lua strings not as a sequence of bytes,
+--    but as a sequence of UTF-8 characters.
+--
+--    Currently, the only practical effect of setting this option is that Unicode LINE and PARAGRAPH
+--    separators, if found in a string, are encoded with a JSON escape instead of being dumped as is.
+--    The JSON is valid either way, but encoding this way, apparently, allows the resulting JSON
+--    to also be valid Java.
+--
+--  AMBIGUOUS SITUATIONS DURING THE ENCODING
+--
+--   During the encode, if a Lua table being encoded contains both string
+--   and numeric keys, it fits neither JSON's idea of an object, nor its
+--   idea of an array. To get around this, when any string key exists (or
+--   when non-positive numeric keys exist), numeric keys are converted to
+--   strings.
+--
+--   For example, 
+--     JSON:encode({ "one", "two", "three", SOMESTRING = "some string" }))
+--   produces the JSON object
+--     {"1":"one","2":"two","3":"three","SOMESTRING":"some string"}
+--
+--   To prohibit this conversion and instead make it an error condition, set
+--      JSON.noKeyConversion = true
+--
+--
+-- ENCODING JSON NULL VALUES
+--
+--   Lua tables completely omit keys whose value is nil, so without special handling there's
+--   no way to get a field in a JSON object with a null value.  For example
+--      JSON:encode({ username = "admin", password = nil })
+--   produces
+--      {"username":"admin"}
+--
+--   In order to actually produce
+--      {"username":"admin", "password":null}
+--   one can include a string value for a "null" field in the options table passed to encode().... 
+--   any Lua table entry with that value becomes null in the JSON output:
+--      JSON:encode({ username = "admin", password = "xyzzy" }, nil, { null = "xyzzy" })
+--   produces
+--      {"username":"admin", "password":null}
+--
+--   Just be sure to use a string that is otherwise unlikely to appear in your data.
+--   The string "\0" (a string with one null byte) may well be appropriate for many applications.
+--
+--   The "null" options also applies to Lua tables that become JSON arrays.
+--      JSON:encode({ "one", "two", nil, nil })
+--   produces
+--      ["one","two"]
+--   while
+--      NULL = "\0"
+--      JSON:encode({ "one", "two", NULL, NULL}, nil, { null = NULL })
+--   produces
+--      ["one","two",null,null]
+--
+--
+--
+--
+-- HANDLING LARGE AND/OR PRECISE NUMBERS
+--
+--
+--   Without special handling, numbers in JSON can lose precision in Lua.
+--   For example:
+--   
+--      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
+--
+--      print("small:   ",  type(T.small),    T.small)
+--      print("big:     ",  type(T.big),      T.big)
+--      print("precise: ",  type(T.precise),  T.precise)
+--   
+--   produces
+--   
+--      small:          number  12345
+--      big:            number  1.2345678901235e+28
+--      precise:        number  9876.6789012346
+--
+--   Precision is lost with both 'big' and 'precise'.
+--
+--   This package offers ways to try to handle this better (for some definitions of "better")...
+--
+--   The most precise method is by setting the global:
+--   
+--      JSON.decodeNumbersAsObjects = true
+--   
+--   When this is set, numeric JSON data is encoded into Lua in a form that preserves the exact
+--   JSON numeric presentation when re-encoded back out to JSON, or accessed in Lua as a string.
+--
+--   (This is done by encoding the numeric data with a Lua table/metatable that returns
+--   the possibly-imprecise numeric form when accessed numerically, but the original precise
+--   representation when accessed as a string. You can also explicitly access
+--   via JSON:forceString() and JSON:forceNumber())
+--
+--   Consider the example above, with this option turned on:
+--
+--      JSON.decodeNumbersAsObjects = true
+--      
+--      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
+--
+--      print("small:   ",  type(T.small),    T.small)
+--      print("big:     ",  type(T.big),      T.big)
+--      print("precise: ",  type(T.precise),  T.precise)
+--   
+--   This now produces:
+--   
+--      small:          table   12345
+--      big:            table   12345678901234567890123456789
+--      precise:        table   9876.67890123456789012345
+--   
+--   However, within Lua you can still use the values (e.g. T.precise in the example above) in numeric
+--   contexts. In such cases you'll get the possibly-imprecise numeric version, but in string contexts
+--   and when the data finds its way to this package's encode() function, the original full-precision
+--   representation is used.
+--
+--   Even without using the JSON.decodeNumbersAsObjects option, you can encode numbers
+--   in your Lua table that retain high precision upon encoding to JSON, by using the JSON:asNumber()
+--   function:
+--
+--      T = {
+--         imprecise = 123456789123456789.123456789123456789,
+--         precise   = JSON:asNumber("123456789123456789.123456789123456789")
+--      }
+--
+--      print(JSON:encode_pretty(T))
+--
+--   This produces:
+--
+--      { 
+--         "precise": 123456789123456789.123456789123456789,
+--         "imprecise": 1.2345678912346e+17
+--      }
+--
+--
+--
+--   A different way to handle big/precise JSON numbers is to have decode() merely return
+--   the exact string representation of the number instead of the number itself.
+--   This approach might be useful when the numbers are merely some kind of opaque
+--   object identifier and you want to work with them in Lua as strings anyway.
+--   
+--   This approach is enabled by setting
+--
+--      JSON.decodeIntegerStringificationLength = 10
+--
+--   The value is the number of digits (of the integer part of the number) at which to stringify numbers.
+--
+--   Consider our previous example with this option set to 10:
+--
+--      JSON.decodeIntegerStringificationLength = 10
+--      
+--      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
+--
+--      print("small:   ",  type(T.small),    T.small)
+--      print("big:     ",  type(T.big),      T.big)
+--      print("precise: ",  type(T.precise),  T.precise)
+--
+--   This produces:
+--
+--      small:          number  12345
+--      big:            string  12345678901234567890123456789
+--      precise:        number  9876.6789012346
+--
+--   The long integer of the 'big' field is at least JSON.decodeIntegerStringificationLength digits
+--   in length, so it's converted not to a Lua integer but to a Lua string. Using a value of 0 or 1 ensures
+--   that all JSON numeric data becomes strings in Lua.
+--
+--   Note that unlike
+--      JSON.decodeNumbersAsObjects = true
+--   this stringification is simple and unintelligent: the JSON number simply becomes a Lua string, and that's the end of it.
+--   If the string is then converted back to JSON, it's still a string. After running the code above, adding
+--      print(JSON:encode(T))
+--   produces
+--      {"big":"12345678901234567890123456789","precise":9876.6789012346,"small":12345}
+--   which is unlikely to be desired.
+--
+--   There's a comparable option for the length of the decimal part of a number:
+--
+--      JSON.decodeDecimalStringificationLength
+--
+--   This can be used alone or in conjunction with
+--
+--      JSON.decodeIntegerStringificationLength
+--
+--   to trip stringification on precise numbers with at least JSON.decodeIntegerStringificationLength digits after
+--   the decimal point.
+--
+--   This example:
+--
+--      JSON.decodeIntegerStringificationLength = 10
+--      JSON.decodeDecimalStringificationLength =  5
+--
+--      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
+--      
+--      print("small:   ",  type(T.small),    T.small)
+--      print("big:     ",  type(T.big),      T.big)
+--      print("precise: ",  type(T.precise),  T.precise)
+--
+--  produces:
+--
+--      small:          number  12345
+--      big:            string  12345678901234567890123456789
+--      precise:        string  9876.67890123456789012345
+--
+--
+--
+--
+--
+-- SUMMARY OF METHODS YOU CAN OVERRIDE IN YOUR LOCAL LUA JSON OBJECT
+--
+--    assert
+--    onDecodeError
+--    onDecodeOfNilError
+--    onDecodeOfHTMLError
+--    onTrailingGarbage
+--    onEncodeError
+--
+--  If you want to create a separate Lua JSON object with its own error handlers,
+--  you can reload JSON.lua or use the :new() method.
+--
+---------------------------------------------------------------------------
+
+local default_pretty_indent  = "  "
+local default_pretty_options = { pretty = true, align_keys = false, indent = default_pretty_indent  }
+
+local isArray  = { __tostring = function() return "JSON array"         end }  isArray.__index  = isArray
+local isObject = { __tostring = function() return "JSON object"        end }  isObject.__index = isObject
+
+function OBJDEF:newArray(tbl)
+   return setmetatable(tbl or {}, isArray)
+end
+
+function OBJDEF:newObject(tbl)
+   return setmetatable(tbl or {}, isObject)
+end
+
+
+
+
+local function getnum(op)
+   return type(op) == 'number' and op or op.N
+end
+
+local isNumber = {
+   __tostring = function(T)  return T.S        end,
+   __unm      = function(op) return getnum(op) end,
+
+   __concat   = function(op1, op2) return tostring(op1) .. tostring(op2) end,
+   __add      = function(op1, op2) return getnum(op1)   +   getnum(op2)  end,
+   __sub      = function(op1, op2) return getnum(op1)   -   getnum(op2)  end,
+   __mul      = function(op1, op2) return getnum(op1)   *   getnum(op2)  end,
+   __div      = function(op1, op2) return getnum(op1)   /   getnum(op2)  end,
+   __mod      = function(op1, op2) return getnum(op1)   %   getnum(op2)  end,
+   __pow      = function(op1, op2) return getnum(op1)   ^   getnum(op2)  end,
+   __lt       = function(op1, op2) return getnum(op1)   <   getnum(op2)  end,
+   __eq       = function(op1, op2) return getnum(op1)   ==  getnum(op2)  end,
+   __le       = function(op1, op2) return getnum(op1)   <=  getnum(op2)  end,
+}
+isNumber.__index = isNumber
+
+function OBJDEF:asNumber(item)
+
+   if getmetatable(item) == isNumber then
+      -- it's already a JSON number object.
+      return item
+   elseif type(item) == 'table' and type(item.S) == 'string' and type(item.N) == 'number' then
+      -- it's a number-object table that lost its metatable, so give it one
+      return setmetatable(item, isNumber)
+   else
+      -- the normal situation... given a number or a string representation of a number....
+      local holder = {
+         S = tostring(item), -- S is the representation of the number as a string, which remains precise
+         N = tonumber(item), -- N is the number as a Lua number.
+      }
+      return setmetatable(holder, isNumber)
+   end
+end
+
+--
+-- Given an item that might be a normal string or number, or might be an 'isNumber' object defined above,
+-- return the string version. This shouldn't be needed often because the 'isNumber' object should autoconvert
+-- to a string in most cases, but it's here to allow it to be forced when needed.
+--
+function OBJDEF:forceString(item)
+   if type(item) == 'table' and type(item.S) == 'string' then
+      return item.S
+   else
+      return tostring(item)
+   end
+end
+
+--
+-- Given an item that might be a normal string or number, or might be an 'isNumber' object defined above,
+-- return the numeric version.
+--
+function OBJDEF:forceNumber(item)
+   if type(item) == 'table' and type(item.N) == 'number' then
+      return item.N
+   else
+      return tonumber(item)
+   end
+end
+   
+
+local function unicode_codepoint_as_utf8(codepoint)
+   --
+   -- codepoint is a number
+   --
+   if codepoint <= 127 then
+      return string.char(codepoint)
+
+   elseif codepoint <= 2047 then
+      --
+      -- 110yyyxx 10xxxxxx         <-- useful notation from http://en.wikipedia.org/wiki/Utf8
+      --
+      local highpart = math.floor(codepoint / 0x40)
+      local lowpart  = codepoint - (0x40 * highpart)
+      return string.char(0xC0 + highpart,
+                         0x80 + lowpart)
+
+   elseif codepoint <= 65535 then
+      --
+      -- 1110yyyy 10yyyyxx 10xxxxxx
+      --
+      local highpart  = math.floor(codepoint / 0x1000)
+      local remainder = codepoint - 0x1000 * highpart
+      local midpart   = math.floor(remainder / 0x40)
+      local lowpart   = remainder - 0x40 * midpart
+
+      highpart = 0xE0 + highpart
+      midpart  = 0x80 + midpart
+      lowpart  = 0x80 + lowpart
+
+      --
+      -- Check for an invalid character (thanks Andy R. at Adobe).
+      -- See table 3.7, page 93, in http://www.unicode.org/versions/Unicode5.2.0/ch03.pdf#G28070
+      --
+      if ( highpart == 0xE0 and midpart < 0xA0 ) or
+         ( highpart == 0xED and midpart > 0x9F ) or
+         ( highpart == 0xF0 and midpart < 0x90 ) or
+         ( highpart == 0xF4 and midpart > 0x8F )
+      then
+         return "?"
+      else
+         return string.char(highpart,
+                            midpart,
+                            lowpart)
+      end
+
+   else
+      --
+      -- 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
+      --
+      local highpart  = math.floor(codepoint / 0x40000)
+      local remainder = codepoint - 0x40000 * highpart
+      local midA      = math.floor(remainder / 0x1000)
+      remainder       = remainder - 0x1000 * midA
+      local midB      = math.floor(remainder / 0x40)
+      local lowpart   = remainder - 0x40 * midB
+
+      return string.char(0xF0 + highpart,
+                         0x80 + midA,
+                         0x80 + midB,
+                         0x80 + lowpart)
+   end
+end
+
+function OBJDEF:onDecodeError(message, text, location, etc)
+   if text then
+      if location then
+         message = string.format("%s at byte %d of: %s", message, location, text)
+      else
+         message = string.format("%s: %s", message, text)
+      end
+   end
+
+   if etc ~= nil then
+      message = message .. " (" .. OBJDEF:encode(etc) .. ")"
+   end
+
+   if self.assert then
+      self.assert(false, message)
+   else
+      assert(false, message)
+   end
+end
+
+function OBJDEF:onTrailingGarbage(json_text, location, parsed_value, etc)
+   return self:onDecodeError("trailing garbage", json_text, location, etc)
+end
+
+OBJDEF.onDecodeOfNilError  = OBJDEF.onDecodeError
+OBJDEF.onDecodeOfHTMLError = OBJDEF.onDecodeError
+
+function OBJDEF:onEncodeError(message, etc)
+   if etc ~= nil then
+      message = message .. " (" .. OBJDEF:encode(etc) .. ")"
+   end
+
+   if self.assert then
+      self.assert(false, message)
+   else
+      assert(false, message)
+   end
+end
+
+local function grok_number(self, text, start, options)
+   --
+   -- Grab the integer part
+   --
+   local integer_part = text:match('^-?[1-9]%d*', start)
+                     or text:match("^-?0",        start)
+
+   if not integer_part then
+      self:onDecodeError("expected number", text, start, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   local i = start + integer_part:len()
+
+   --
+   -- Grab an optional decimal part
+   --
+   local decimal_part = text:match('^%.%d+', i) or ""
+
+   i = i + decimal_part:len()
+
+   --
+   -- Grab an optional exponential part
+   --
+   local exponent_part = text:match('^[eE][-+]?%d+', i) or ""
+
+   i = i + exponent_part:len()
+
+   local full_number_text = integer_part .. decimal_part .. exponent_part
+
+   if options.decodeNumbersAsObjects then
+      return OBJDEF:asNumber(full_number_text), i
+   end
+
+   --
+   -- If we're told to stringify under certain conditions, so do.
+   -- We punt a bit when there's an exponent by just stringifying no matter what.
+   -- I suppose we should really look to see whether the exponent is actually big enough one
+   -- way or the other to trip stringification, but I'll be lazy about it until someone asks.
+   --
+   if (options.decodeIntegerStringificationLength
+       and
+      (integer_part:len() >= options.decodeIntegerStringificationLength or exponent_part:len() > 0))
+
+       or
+
+      (options.decodeDecimalStringificationLength 
+       and
+       (decimal_part:len() >= options.decodeDecimalStringificationLength or exponent_part:len() > 0))
+   then
+      return full_number_text, i -- this returns the exact string representation seen in the original JSON
+   end
+
+
+
+   local as_number = tonumber(full_number_text)
+
+   if not as_number then
+      self:onDecodeError("bad number", text, start, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   return as_number, i
+end
+
+
+local function grok_string(self, text, start, options)
+
+   if text:sub(start,start) ~= '"' then
+      self:onDecodeError("expected string's opening quote", text, start, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   local i = start + 1 -- +1 to bypass the initial quote
+   local text_len = text:len()
+   local VALUE = ""
+   while i <= text_len do
+      local c = text:sub(i,i)
+      if c == '"' then
+         return VALUE, i + 1
+      end
+      if c ~= '\\' then
+         VALUE = VALUE .. c
+         i = i + 1
+      elseif text:match('^\\b', i) then
+         VALUE = VALUE .. "\b"
+         i = i + 2
+      elseif text:match('^\\f', i) then
+         VALUE = VALUE .. "\f"
+         i = i + 2
+      elseif text:match('^\\n', i) then
+         VALUE = VALUE .. "\n"
+         i = i + 2
+      elseif text:match('^\\r', i) then
+         VALUE = VALUE .. "\r"
+         i = i + 2
+      elseif text:match('^\\t', i) then
+         VALUE = VALUE .. "\t"
+         i = i + 2
+      else
+         local hex = text:match('^\\u([0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])', i)
+         if hex then
+            i = i + 6 -- bypass what we just read
+
+            -- We have a Unicode codepoint. It could be standalone, or if in the proper range and
+            -- followed by another in a specific range, it'll be a two-code surrogate pair.
+            local codepoint = tonumber(hex, 16)
+            if codepoint >= 0xD800 and codepoint <= 0xDBFF then
+               -- it's a hi surrogate... see whether we have a following low
+               local lo_surrogate = text:match('^\\u([dD][cdefCDEF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])', i)
+               if lo_surrogate then
+                  i = i + 6 -- bypass the low surrogate we just read
+                  codepoint = 0x2400 + (codepoint - 0xD800) * 0x400 + tonumber(lo_surrogate, 16)
+               else
+                  -- not a proper low, so we'll just leave the first codepoint as is and spit it out.
+               end
+            end
+            VALUE = VALUE .. unicode_codepoint_as_utf8(codepoint)
+
+         else
+
+            -- just pass through what's escaped
+            VALUE = VALUE .. text:match('^\\(.)', i)
+            i = i + 2
+         end
+      end
+   end
+
+   self:onDecodeError("unclosed string", text, start, options.etc)
+   return nil, start -- in case the error method doesn't abort, return something sensible
+end
+
+local function skip_whitespace(text, start)
+
+   local _, match_end = text:find("^[ \n\r\t]+", start) -- [http://www.ietf.org/rfc/rfc4627.txt] Section 2
+   if match_end then
+      return match_end + 1
+   else
+      return start
+   end
+end
+
+local grok_one -- assigned later
+
+local function grok_object(self, text, start, options)
+
+   if text:sub(start,start) ~= '{' then
+      self:onDecodeError("expected '{'", text, start, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   local i = skip_whitespace(text, start + 1) -- +1 to skip the '{'
+
+   local VALUE = self.strictTypes and self:newObject { } or { }
+
+   if text:sub(i,i) == '}' then
+      return VALUE, i + 1
+   end
+   local text_len = text:len()
+   while i <= text_len do
+      local key, new_i = grok_string(self, text, i, options)
+
+      i = skip_whitespace(text, new_i)
+
+      if text:sub(i, i) ~= ':' then
+         self:onDecodeError("expected colon", text, i, options.etc)
+         return nil, i -- in case the error method doesn't abort, return something sensible
+      end
+
+      i = skip_whitespace(text, i + 1)
+
+      local new_val, new_i = grok_one(self, text, i, options)
+
+      VALUE[key] = new_val
+
+      --
+      -- Expect now either '}' to end things, or a ',' to allow us to continue.
+      --
+      i = skip_whitespace(text, new_i)
+
+      local c = text:sub(i,i)
+
+      if c == '}' then
+         return VALUE, i + 1
+      end
+
+      if text:sub(i, i) ~= ',' then
+         self:onDecodeError("expected comma or '}'", text, i, options.etc)
+         return nil, i -- in case the error method doesn't abort, return something sensible
+      end
+
+      i = skip_whitespace(text, i + 1)
+   end
+
+   self:onDecodeError("unclosed '{'", text, start, options.etc)
+   return nil, start -- in case the error method doesn't abort, return something sensible
+end
+
+local function grok_array(self, text, start, options)
+   if text:sub(start,start) ~= '[' then
+      self:onDecodeError("expected '['", text, start, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   local i = skip_whitespace(text, start + 1) -- +1 to skip the '['
+   local VALUE = self.strictTypes and self:newArray { } or { }
+   if text:sub(i,i) == ']' then
+      return VALUE, i + 1
+   end
+
+   local VALUE_INDEX = 1
+
+   local text_len = text:len()
+   while i <= text_len do
+      local val, new_i = grok_one(self, text, i, options)
+
+      -- can't table.insert(VALUE, val) here because it's a no-op if val is nil
+      VALUE[VALUE_INDEX] = val
+      VALUE_INDEX = VALUE_INDEX + 1
+
+      i = skip_whitespace(text, new_i)
+
+      --
+      -- Expect now either ']' to end things, or a ',' to allow us to continue.
+      --
+      local c = text:sub(i,i)
+      if c == ']' then
+         return VALUE, i + 1
+      end
+      if text:sub(i, i) ~= ',' then
+         self:onDecodeError("expected comma or ']'", text, i, options.etc)
+         return nil, i -- in case the error method doesn't abort, return something sensible
+      end
+      i = skip_whitespace(text, i + 1)
+   end
+   self:onDecodeError("unclosed '['", text, start, options.etc)
+   return nil, i -- in case the error method doesn't abort, return something sensible
+end
+
+
+grok_one = function(self, text, start, options)
+   -- Skip any whitespace
+   start = skip_whitespace(text, start)
+
+   if start > text:len() then
+      self:onDecodeError("unexpected end of string", text, nil, options.etc)
+      return nil, start -- in case the error method doesn't abort, return something sensible
+   end
+
+   if text:find('^"', start) then
+      return grok_string(self, text, start, options.etc)
+
+   elseif text:find('^[-0123456789 ]', start) then
+      return grok_number(self, text, start, options)
+
+   elseif text:find('^%{', start) then
+      return grok_object(self, text, start, options)
+
+   elseif text:find('^%[', start) then
+      return grok_array(self, text, start, options)
+
+   elseif text:find('^true', start) then
+      return true, start + 4
+
+   elseif text:find('^false', start) then
+      return false, start + 5
+
+   elseif text:find('^null', start) then
+      return nil, start + 4
+
+   else
+      self:onDecodeError("can't parse JSON", text, start, options.etc)
+      return nil, 1 -- in case the error method doesn't abort, return something sensible
+   end
+end
+
+function OBJDEF:decode(text, etc, options)
+   --
+   -- If the user didn't pass in a table of decode options, make an empty one.
+   --
+   if type(options) ~= 'table' then
+      options = {}
+   end
+
+   --
+   -- If they passed in an 'etc' argument, stuff it into the options.
+   -- (If not, any 'etc' field in the options they passed in remains to be used)
+   --
+   if etc ~= nil then
+      options.etc = etc
+   end
+
+
+   if type(self) ~= 'table' or self.__index ~= OBJDEF then
+      local error_message = "JSON:decode must be called in method format"
+      OBJDEF:onDecodeError(error_message, nil, nil, options.etc)
+      return nil, error_message -- in case the error method doesn't abort, return something sensible
+   end
+
+   if text == nil then
+      local error_message = "nil passed to JSON:decode()"
+      self:onDecodeOfNilError(error_message, nil, nil, options.etc)
+      return nil, error_message -- in case the error method doesn't abort, return something sensible
+
+   elseif type(text) ~= 'string' then
+      local error_message = "expected string argument to JSON:decode()"
+      self:onDecodeError(string.format("%s, got %s", error_message, type(text)), nil, nil, options.etc)
+      return nil, error_message -- in case the error method doesn't abort, return something sensible
+   end
+
+   if text:match('^%s*$') then
+      -- an empty string is nothing, but not an error
+      return nil
+   end
+
+   if text:match('^%s*<') then
+      -- Can't be JSON... we'll assume it's HTML
+      local error_message = "HTML passed to JSON:decode()"
+      self:onDecodeOfHTMLError(error_message, text, nil, options.etc)
+      return nil, error_message -- in case the error method doesn't abort, return something sensible
+   end
+
+   --
+   -- Ensure that it's not UTF-32 or UTF-16.
+   -- Those are perfectly valid encodings for JSON (as per RFC 4627 section 3),
+   -- but this package can't handle them.
+   --
+   if text:sub(1,1):byte() == 0 or (text:len() >= 2 and text:sub(2,2):byte() == 0) then
+      local error_message = "JSON package groks only UTF-8, sorry"
+      self:onDecodeError(error_message, text, nil, options.etc)
+      return nil, error_message -- in case the error method doesn't abort, return something sensible
+   end
+
+   --
+   -- apply global options
+   --
+   if options.decodeNumbersAsObjects == nil then
+      options.decodeNumbersAsObjects = self.decodeNumbersAsObjects
+   end
+   if options.decodeIntegerStringificationLength == nil then
+      options.decodeIntegerStringificationLength = self.decodeIntegerStringificationLength
+   end
+   if options.decodeDecimalStringificationLength == nil then
+      options.decodeDecimalStringificationLength = self.decodeDecimalStringificationLength
+   end
+
+   --
+   -- Finally, go parse it
+   --
+   local success, value, next_i = pcall(grok_one, self, text, 1, options)
+
+   if success then
+
+      local error_message = nil
+      if next_i ~= #text + 1 then
+         -- something's left over after we parsed the first thing.... whitespace is allowed.
+         next_i = skip_whitespace(text, next_i)
+
+         -- if we have something left over now, it's trailing garbage
+         if next_i ~= #text + 1 then
+            value, error_message = self:onTrailingGarbage(text, next_i, value, options.etc)
+         end
+      end
+      return value, error_message
+
+   else
+
+      -- If JSON:onDecodeError() didn't abort out of the pcall, we'll have received
+      -- the error message here as "value", so pass it along as an assert.
+      local error_message = value
+      if self.assert then
+         self.assert(false, error_message)
+      else
+         assert(false, error_message)
+      end
+      -- ...and if we're still here (because the assert didn't throw an error),
+      -- return a nil and throw the error message on as a second arg
+      return nil, error_message
+
+   end
+end
+
+local function backslash_replacement_function(c)
+   if c == "\n" then
+      return "\\n"
+   elseif c == "\r" then
+      return "\\r"
+   elseif c == "\t" then
+      return "\\t"
+   elseif c == "\b" then
+      return "\\b"
+   elseif c == "\f" then
+      return "\\f"
+   elseif c == '"' then
+      return '\\"'
+   elseif c == '\\' then
+      return '\\\\'
+   else
+      return string.format("\\u%04x", c:byte())
+   end
+end
+
+local chars_to_be_escaped_in_JSON_string
+   = '['
+   ..    '"'    -- class sub-pattern to match a double quote
+   ..    '%\\'  -- class sub-pattern to match a backslash
+   ..    '%z'   -- class sub-pattern to match a null
+   ..    '\001' .. '-' .. '\031' -- class sub-pattern to match control characters
+   .. ']'
+
+
+local LINE_SEPARATOR_as_utf8      = unicode_codepoint_as_utf8(0x2028)
+local PARAGRAPH_SEPARATOR_as_utf8 = unicode_codepoint_as_utf8(0x2029)
+local function json_string_literal(value, options)
+   local newval = value:gsub(chars_to_be_escaped_in_JSON_string, backslash_replacement_function)
+   if options.stringsAreUtf8 then
+      --
+      -- This feels really ugly to just look into a string for the sequence of bytes that we know to be a particular utf8 character,
+      -- but utf8 was designed purposefully to make this kind of thing possible. Still, feels dirty.
+      -- I'd rather decode the byte stream into a character stream, but it's not technically needed so
+      -- not technically worth it.
+      --
+      newval = newval:gsub(LINE_SEPARATOR_as_utf8, '\\u2028'):gsub(PARAGRAPH_SEPARATOR_as_utf8,'\\u2029')
+   end
+   return '"' .. newval .. '"'
+end
+
+local function object_or_array(self, T, etc)
+   --
+   -- We need to inspect all the keys... if there are any strings, we'll convert to a JSON
+   -- object. If there are only numbers, it's a JSON array.
+   --
+   -- If we'll be converting to a JSON object, we'll want to sort the keys so that the
+   -- end result is deterministic.
+   --
+   local string_keys = { }
+   local number_keys = { }
+   local number_keys_must_be_strings = false
+   local maximum_number_key
+
+   for key in pairs(T) do
+      if type(key) == 'string' then
+         table.insert(string_keys, key)
+      elseif type(key) == 'number' then
+         table.insert(number_keys, key)
+         if key <= 0 or key >= math.huge then
+            number_keys_must_be_strings = true
+         elseif not maximum_number_key or key > maximum_number_key then
+            maximum_number_key = key
+         end
+      else
+         self:onEncodeError("can't encode table with a key of type " .. type(key), etc)
+      end
+   end
+
+   if #string_keys == 0 and not number_keys_must_be_strings then
+      --
+      -- An empty table, or a numeric-only array
+      --
+      if #number_keys > 0 then
+         return nil, maximum_number_key -- an array
+      elseif tostring(T) == "JSON array" then
+         return nil
+      elseif tostring(T) == "JSON object" then
+         return { }
+      else
+         -- have to guess, so we'll pick array, since empty arrays are likely more common than empty objects
+         return nil
+      end
+   end
+
+   table.sort(string_keys)
+
+   local map
+   if #number_keys > 0 then
+      --
+      -- If we're here then we have either mixed string/number keys, or numbers inappropriate for a JSON array
+      -- It's not ideal, but we'll turn the numbers into strings so that we can at least create a JSON object.
+      --
+
+      if self.noKeyConversion then
+         self:onEncodeError("a table with both numeric and string keys could be an object or array; aborting", etc)
+      end
+
+      --
+      -- Have to make a shallow copy of the source table so we can remap the numeric keys to be strings
+      --
+      map = { }
+      for key, val in pairs(T) do
+         map[key] = val
+      end
+
+      table.sort(number_keys)
+
+      --
+      -- Throw numeric keys in there as strings
+      --
+      for _, number_key in ipairs(number_keys) do
+         local string_key = tostring(number_key)
+         if map[string_key] == nil then
+            table.insert(string_keys , string_key)
+            map[string_key] = T[number_key]
+         else
+            self:onEncodeError("conflict converting table with mixed-type keys into a JSON object: key " .. number_key .. " exists both as a string and a number.", etc)
+         end
+      end
+   end
+
+   return string_keys, nil, map
+end
+
+--
+-- Encode
+--
+-- 'options' is nil, or a table with possible keys:
+--
+--    pretty         -- If true, return a pretty-printed version.
+--
+--    indent         -- A string (usually of spaces) used to indent each nested level.
+--
+--    align_keys     -- If true, align all the keys when formatting a table.
+--
+--    null           -- If this exists with a string value, table elements with this value are output as JSON null.
+--
+--    stringsAreUtf8 -- If true, consider Lua strings not as a sequence of bytes, but as a sequence of UTF-8 characters.
+--                      (Currently, the only practical effect of setting this option is that Unicode LINE and PARAGRAPH
+--                       separators, if found in a string, are encoded with a JSON escape instead of as raw UTF-8.
+--                       The JSON is valid either way, but encoding this way, apparently, allows the resulting JSON
+--                       to also be valid Java.)
+--
+--
+local encode_value -- must predeclare because it calls itself
+function encode_value(self, value, parents, etc, options, indent, for_key)
+
+   --
+   -- keys in a JSON object can never be null, so we don't even consider options.null when converting a key value
+   --
+   if value == nil or (not for_key and options and options.null and value == options.null) then
+      return 'null'
+
+   elseif type(value) == 'string' then
+      return json_string_literal(value, options)
+
+   elseif type(value) == 'number' then
+      if value ~= value then
+         --
+         -- NaN (Not a Number).
+         -- JSON has no NaN, so we have to fudge the best we can. This should really be a package option.
+         --
+         return "null"
+      elseif value >= math.huge then
+         --
+         -- Positive infinity. JSON has no INF, so we have to fudge the best we can. This should
+         -- really be a package option. Note: at least with some implementations, positive infinity
+         -- is both ">= math.huge" and "<= -math.huge", which makes no sense but that's how it is.
+         -- Negative infinity is properly "<= -math.huge". So, we must be sure to check the ">="
+         -- case first.
+         --
+         return "1e+9999"
+      elseif value <= -math.huge then
+         --
+         -- Negative infinity.
+         -- JSON has no INF, so we have to fudge the best we can. This should really be a package option.
+         --
+         return "-1e+9999"
+      else
+         return tostring(value)
+      end
+
+   elseif type(value) == 'boolean' then
+      return tostring(value)
+
+   elseif type(value) ~= 'table' then
+      self:onEncodeError("can't convert " .. type(value) .. " to JSON", etc)
+
+   elseif getmetatable(value) == isNumber then
+      return tostring(value)
+   else
+      --
+      -- A table to be converted to either a JSON object or array.
+      --
+      local T = value
+
+      if type(options) ~= 'table' then
+         options = {}
+      end
+      if type(indent) ~= 'string' then
+         indent = ""
+      end
+
+      if parents[T] then
+         self:onEncodeError("table " .. tostring(T) .. " is a child of itself", etc)
+      else
+         parents[T] = true
+      end
+
+      local result_value
+
+      local object_keys, maximum_number_key, map = object_or_array(self, T, etc)
+      if maximum_number_key then
+         --
+         -- An array...
+         --
+         local ITEMS = { }
+         local key_indent = indent .. tostring(options.indent or "")
+         for i = 1, maximum_number_key do
+            if not options.array_newline then
+               table.insert(ITEMS, encode_value(self, T[i], parents, etc, options, indent))
+            else
+               table.insert(ITEMS, encode_value(self, T[i], parents, etc, options, key_indent))
+            end
+         end
+
+         if options.pretty then
+            if not options.array_newline then
+               result_value = "[ " .. table.concat(ITEMS, ", ") .. " ]"
+            else
+               result_value =  "[\n"  ..  key_indent .. table.concat(ITEMS, ",\n" .. key_indent) .. "\n" ..  indent .. "]"
+            end
+         else
+            result_value = "["  .. table.concat(ITEMS, ",")  .. "]"
+         end
+
+      elseif object_keys then
+         --
+         -- An object
+         --
+         local TT = map or T
+
+         if options.pretty then
+
+            local KEYS = { }
+            local max_key_length = 0
+            for _, key in ipairs(object_keys) do
+               local encoded = encode_value(self, tostring(key), parents, etc, options, indent, true)
+               if options.align_keys then
+                  max_key_length = math.max(max_key_length, #encoded)
+               end
+               table.insert(KEYS, encoded)
+            end
+            local key_indent = indent .. tostring(options.indent or "")
+            local subtable_indent = key_indent .. string.rep(" ", max_key_length) .. (options.align_keys and "  " or "")
+            local FORMAT = "%s%" .. string.format("%d", max_key_length) .. "s: %s"
+
+            local COMBINED_PARTS = { }
+            for i, key in ipairs(object_keys) do
+               local encoded_val = encode_value(self, TT[key], parents, etc, options, subtable_indent)
+               table.insert(COMBINED_PARTS, string.format(FORMAT, key_indent, KEYS[i], encoded_val))
+            end
+            result_value = "{\n" .. table.concat(COMBINED_PARTS, ",\n") .. "\n" .. indent .. "}"
+
+         else
+
+            local PARTS = { }
+            for _, key in ipairs(object_keys) do
+               local encoded_val = encode_value(self, TT[key],       parents, etc, options, indent)
+               local encoded_key = encode_value(self, tostring(key), parents, etc, options, indent, true)
+               table.insert(PARTS, string.format("%s:%s", encoded_key, encoded_val))
+            end
+            result_value = "{" .. table.concat(PARTS, ",") .. "}"
+
+         end
+      else
+         --
+         -- An empty array/object... we'll treat it as an array, though it should really be an option
+         --
+         result_value = "[]"
+      end
+
+      parents[T] = false
+      return result_value
+   end
+end
+
+local function top_level_encode(self, value, etc, options)
+   local val = encode_value(self, value, {}, etc, options)
+   if val == nil then
+      --PRIVATE("may need to revert to the previous public verison if I can't figure out what the guy wanted")
+      return val
+   else
+      return val
+   end
+end
+
+function OBJDEF:encode(value, etc, options)
+   if type(self) ~= 'table' or self.__index ~= OBJDEF then
+      OBJDEF:onEncodeError("JSON:encode must be called in method format", etc)
+   end
+
+   --
+   -- If the user didn't pass in a table of decode options, make an empty one.
+   --
+   if type(options) ~= 'table' then
+      options = {}
+   end
+
+   return top_level_encode(self, value, etc, options)
+end
+
+function OBJDEF:encode_pretty(value, etc, options)
+   if type(self) ~= 'table' or self.__index ~= OBJDEF then
+      OBJDEF:onEncodeError("JSON:encode_pretty must be called in method format", etc)
+   end
+
+   --
+   -- If the user didn't pass in a table of decode options, use the default pretty ones
+   --
+   if type(options) ~= 'table' then
+      options = default_pretty_options
+   end
+
+   return top_level_encode(self, value, etc, options)
+end
+
+function OBJDEF.__tostring()
+   return "JSON encode/decode package"
+end
+
+OBJDEF.__index = OBJDEF
+
+function OBJDEF:new(args)
+   local new = { }
+
+   if args then
+      for key, val in pairs(args) do
+         new[key] = val
+      end
+   end
+
+   return setmetatable(new, OBJDEF)
+end
+
+return OBJDEF:new()
+
+--
+-- Version history:
+--
+--   20161109.21   Oops, had a small boo-boo in the previous update.
+--
+--   20161103.20   Used to silently ignore trailing garbage when decoding. Now fails via JSON:onTrailingGarbage()
+--                 http://seriot.ch/parsing_json.php
+--
+--                 Built-in error message about "expected comma or ']'" had mistakenly referred to '['
+--
+--                 Updated the built-in error reporting to refer to bytes rather than characters.
+--
+--                 The decode() method no longer assumes that error handlers abort.
+--
+--                 Made the VERSION string a string instead of a number
+--
+
+--   20160916.19   Fixed the isNumber.__index assignment (thanks to Jack Taylor)
+--   
+--   20160730.18   Added JSON:forceString() and JSON:forceNumber()
+--
+--   20160728.17   Added concatenation to the metatable for JSON:asNumber()
+--
+--   20160709.16   Could crash if not passed an options table (thanks jarno heikkinen <jarnoh@capturemonkey.com>).
+--
+--                 Made JSON:asNumber() a bit more resilient to being passed the results of itself.
+--
+--   20160526.15   Added the ability to easily encode null values in JSON, via the new "null" encoding option.
+--                 (Thanks to Adam B for bringing up the issue.)
+--
+--                 Added some support for very large numbers and precise floats via
+--                    JSON.decodeNumbersAsObjects
+--                    JSON.decodeIntegerStringificationLength
+--                    JSON.decodeDecimalStringificationLength
+--
+--                 Added the "stringsAreUtf8" encoding option. (Hat tip to http://lua-users.org/wiki/JsonModules )
+--
+--   20141223.14   The encode_pretty() routine produced fine results for small datasets, but isn't really
+--                 appropriate for anything large, so with help from Alex Aulbach I've made the encode routines
+--                 more flexible, and changed the default encode_pretty() to be more generally useful.
+--
+--                 Added a third 'options' argument to the encode() and encode_pretty() routines, to control
+--                 how the encoding takes place.
+--
+--                 Updated docs to add assert() call to the loadfile() line, just as good practice so that
+--                 if there is a problem loading JSON.lua, the appropriate error message will percolate up.
+--
+--   20140920.13   Put back (in a way that doesn't cause warnings about unused variables) the author string,
+--                 so that the source of the package, and its version number, are visible in compiled copies.
+--
+--   20140911.12   Minor lua cleanup.
+--                 Fixed internal reference to 'JSON.noKeyConversion' to reference 'self' instead of 'JSON'.
+--                 (Thanks to SmugMug's David Parry for these.)
+--
+--   20140418.11   JSON nulls embedded within an array were being ignored, such that
+--                     ["1",null,null,null,null,null,"seven"],
+--                 would return
+--                     {1,"seven"}
+--                 It's now fixed to properly return
+--                     {1, nil, nil, nil, nil, nil, "seven"}
+--                 Thanks to "haddock" for catching the error.
+--
+--   20140116.10   The user's JSON.assert() wasn't always being used. Thanks to "blue" for the heads up.
+--
+--   20131118.9    Update for Lua 5.3... it seems that tostring(2/1) produces "2.0" instead of "2",
+--                 and this caused some problems.
+--
+--   20131031.8    Unified the code for encode() and encode_pretty(); they had been stupidly separate,
+--                 and had of course diverged (encode_pretty didn't get the fixes that encode got, so
+--                 sometimes produced incorrect results; thanks to Mattie for the heads up).
+--
+--                 Handle encoding tables with non-positive numeric keys (unlikely, but possible).
+--
+--                 If a table has both numeric and string keys, or its numeric keys are inappropriate
+--                 (such as being non-positive or infinite), the numeric keys are turned into
+--                 string keys appropriate for a JSON object. So, as before,
+--                         JSON:encode({ "one", "two", "three" })
+--                 produces the array
+--                         ["one","two","three"]
+--                 but now something with mixed key types like
+--                         JSON:encode({ "one", "two", "three", SOMESTRING = "some string" }))
+--                 instead of throwing an error produces an object:
+--                         {"1":"one","2":"two","3":"three","SOMESTRING":"some string"}
+--
+--                 To maintain the prior throw-an-error semantics, set
+--                      JSON.noKeyConversion = true
+--                 
+--   20131004.7    Release under a Creative Commons CC-BY license, which I should have done from day one, sorry.
+--
+--   20130120.6    Comment update: added a link to the specific page on my blog where this code can
+--                 be found, so that folks who come across the code outside of my blog can find updates
+--                 more easily.
+--
+--   20111207.5    Added support for the 'etc' arguments, for better error reporting.
+--
+--   20110731.4    More feedback from David Kolf on how to make the tests for Nan/Infinity system independent.
+--
+--   20110730.3    Incorporated feedback from David Kolf at http://lua-users.org/wiki/JsonModules:
+--
+--                   * When encoding lua for JSON, Sparse numeric arrays are now handled by
+--                     spitting out full arrays, such that
+--                        JSON:encode({"one", "two", [10] = "ten"})
+--                     returns
+--                        ["one","two",null,null,null,null,null,null,null,"ten"]
+--
+--                     In 20100810.2 and earlier, only up to the first non-null value would have been retained.
+--
+--                   * When encoding lua for JSON, numeric value NaN gets spit out as null, and infinity as "1+e9999".
+--                     Version 20100810.2 and earlier created invalid JSON in both cases.
+--
+--                   * Unicode surrogate pairs are now detected when decoding JSON.
+--
+--   20100810.2    added some checking to ensure that an invalid Unicode character couldn't leak in to the UTF-8 encoding
+--
+--   20100731.1    initial public release
+--

--- a/vendor/share/lua/5.1/JSON.lua
+++ b/vendor/share/lua/5.1/JSON.lua
@@ -15,7 +15,8 @@
 --    3) the 'AUTHOR_NOTE' string below is maintained
 --
 local VERSION = '20161109.21' -- version history at end of file
-local AUTHOR_NOTE = "-[ JSON.lua package by Jeffrey Friedl (http://regex.info/blog/lua/json) version 20161109.21 ]-"
+local AUTHOR_NOTE =
+    '-[ JSON.lua package by Jeffrey Friedl (http://regex.info/blog/lua/json) version 20161109.21 ]-'
 
 --
 -- The 'AUTHOR_NOTE' variable exists so that information about the source
@@ -23,10 +24,9 @@ local AUTHOR_NOTE = "-[ JSON.lua package by Jeffrey Friedl (http://regex.info/bl
 -- included in OBJDEF below mostly to quiet warnings about unused variables.
 --
 local OBJDEF = {
-   VERSION      = VERSION,
-   AUTHOR_NOTE  = AUTHOR_NOTE,
+    VERSION = VERSION,
+    AUTHOR_NOTE = AUTHOR_NOTE,
 }
-
 
 --
 -- Simple JSON encoding and decoding in pure Lua.
@@ -119,11 +119,11 @@ local OBJDEF = {
 --            :
 --
 --          for i, photo in ipairs(photosToProcess) do
---               :             
---               :             
+--               :
+--               :
 --               local data = JSON:decode(someJsonText, { photo = photo })
---               :             
---               :             
+--               :
+--               :
 --          end
 --
 --
@@ -201,12 +201,12 @@ local OBJDEF = {
 --           indent         = "   ",
 --           align_keys     = false,
 --           array_newline  = false,
---  
+--
 --           -- other output-related options
 --           null           = "\0",   -- see "ENCODING JSON NULL VALUES" below
 --           stringsAreUtf8 = false,  -- see "HANDLING UNICODE LINE AND PARAGRAPH SEPARATORS FOR JAVA" below
 --       }
---  
+--
 --       json_string = JSON:encode(mytable, etc, encode_options)
 --
 --
@@ -285,9 +285,9 @@ local OBJDEF = {
 --   An example of setting align_keys to true:
 --
 --     JSON:encode_pretty(data, nil, { pretty = true, indent = "  ", align_keys = true })
---  
+--
 --   produces:
---   
+--
 --      {
 --           "city": "Kyoto",
 --        "climate": {
@@ -321,7 +321,7 @@ local OBJDEF = {
 --   when non-positive numeric keys exist), numeric keys are converted to
 --   strings.
 --
---   For example, 
+--   For example,
 --     JSON:encode({ "one", "two", "three", SOMESTRING = "some string" }))
 --   produces the JSON object
 --     {"1":"one","2":"two","3":"three","SOMESTRING":"some string"}
@@ -340,7 +340,7 @@ local OBJDEF = {
 --
 --   In order to actually produce
 --      {"username":"admin", "password":null}
---   one can include a string value for a "null" field in the options table passed to encode().... 
+--   one can include a string value for a "null" field in the options table passed to encode()....
 --   any Lua table entry with that value becomes null in the JSON output:
 --      JSON:encode({ username = "admin", password = "xyzzy" }, nil, { null = "xyzzy" })
 --   produces
@@ -367,15 +367,15 @@ local OBJDEF = {
 --
 --   Without special handling, numbers in JSON can lose precision in Lua.
 --   For example:
---   
+--
 --      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
 --
 --      print("small:   ",  type(T.small),    T.small)
 --      print("big:     ",  type(T.big),      T.big)
 --      print("precise: ",  type(T.precise),  T.precise)
---   
+--
 --   produces
---   
+--
 --      small:          number  12345
 --      big:            number  1.2345678901235e+28
 --      precise:        number  9876.6789012346
@@ -385,9 +385,9 @@ local OBJDEF = {
 --   This package offers ways to try to handle this better (for some definitions of "better")...
 --
 --   The most precise method is by setting the global:
---   
+--
 --      JSON.decodeNumbersAsObjects = true
---   
+--
 --   When this is set, numeric JSON data is encoded into Lua in a form that preserves the exact
 --   JSON numeric presentation when re-encoded back out to JSON, or accessed in Lua as a string.
 --
@@ -399,19 +399,19 @@ local OBJDEF = {
 --   Consider the example above, with this option turned on:
 --
 --      JSON.decodeNumbersAsObjects = true
---      
+--
 --      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
 --
 --      print("small:   ",  type(T.small),    T.small)
 --      print("big:     ",  type(T.big),      T.big)
 --      print("precise: ",  type(T.precise),  T.precise)
---   
+--
 --   This now produces:
---   
+--
 --      small:          table   12345
 --      big:            table   12345678901234567890123456789
 --      precise:        table   9876.67890123456789012345
---   
+--
 --   However, within Lua you can still use the values (e.g. T.precise in the example above) in numeric
 --   contexts. In such cases you'll get the possibly-imprecise numeric version, but in string contexts
 --   and when the data finds its way to this package's encode() function, the original full-precision
@@ -430,7 +430,7 @@ local OBJDEF = {
 --
 --   This produces:
 --
---      { 
+--      {
 --         "precise": 123456789123456789.123456789123456789,
 --         "imprecise": 1.2345678912346e+17
 --      }
@@ -441,7 +441,7 @@ local OBJDEF = {
 --   the exact string representation of the number instead of the number itself.
 --   This approach might be useful when the numbers are merely some kind of opaque
 --   object identifier and you want to work with them in Lua as strings anyway.
---   
+--
 --   This approach is enabled by setting
 --
 --      JSON.decodeIntegerStringificationLength = 10
@@ -451,7 +451,7 @@ local OBJDEF = {
 --   Consider our previous example with this option set to 10:
 --
 --      JSON.decodeIntegerStringificationLength = 10
---      
+--
 --      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
 --
 --      print("small:   ",  type(T.small),    T.small)
@@ -494,7 +494,7 @@ local OBJDEF = {
 --      JSON.decodeDecimalStringificationLength =  5
 --
 --      T = JSON:decode('{  "small":12345, "big":12345678901234567890123456789, "precise":9876.67890123456789012345  }')
---      
+--
 --      print("small:   ",  type(T.small),    T.small)
 --      print("big:     ",  type(T.big),      T.big)
 --      print("precise: ",  type(T.precise),  T.precise)
@@ -523,60 +523,95 @@ local OBJDEF = {
 --
 ---------------------------------------------------------------------------
 
-local default_pretty_indent  = "  "
-local default_pretty_options = { pretty = true, align_keys = false, indent = default_pretty_indent  }
+local default_pretty_indent = '  '
+local default_pretty_options =
+    { pretty = true, align_keys = false, indent = default_pretty_indent }
 
-local isArray  = { __tostring = function() return "JSON array"         end }  isArray.__index  = isArray
-local isObject = { __tostring = function() return "JSON object"        end }  isObject.__index = isObject
+local isArray = {
+    __tostring = function()
+        return 'JSON array'
+    end,
+}
+isArray.__index = isArray
+local isObject = {
+    __tostring = function()
+        return 'JSON object'
+    end,
+}
+isObject.__index = isObject
 
 function OBJDEF:newArray(tbl)
-   return setmetatable(tbl or {}, isArray)
+    return setmetatable(tbl or {}, isArray)
 end
 
 function OBJDEF:newObject(tbl)
-   return setmetatable(tbl or {}, isObject)
+    return setmetatable(tbl or {}, isObject)
 end
 
-
-
-
 local function getnum(op)
-   return type(op) == 'number' and op or op.N
+    return type(op) == 'number' and op or op.N
 end
 
 local isNumber = {
-   __tostring = function(T)  return T.S        end,
-   __unm      = function(op) return getnum(op) end,
+    __tostring = function(T)
+        return T.S
+    end,
+    __unm = function(op)
+        return getnum(op)
+    end,
 
-   __concat   = function(op1, op2) return tostring(op1) .. tostring(op2) end,
-   __add      = function(op1, op2) return getnum(op1)   +   getnum(op2)  end,
-   __sub      = function(op1, op2) return getnum(op1)   -   getnum(op2)  end,
-   __mul      = function(op1, op2) return getnum(op1)   *   getnum(op2)  end,
-   __div      = function(op1, op2) return getnum(op1)   /   getnum(op2)  end,
-   __mod      = function(op1, op2) return getnum(op1)   %   getnum(op2)  end,
-   __pow      = function(op1, op2) return getnum(op1)   ^   getnum(op2)  end,
-   __lt       = function(op1, op2) return getnum(op1)   <   getnum(op2)  end,
-   __eq       = function(op1, op2) return getnum(op1)   ==  getnum(op2)  end,
-   __le       = function(op1, op2) return getnum(op1)   <=  getnum(op2)  end,
+    __concat = function(op1, op2)
+        return tostring(op1) .. tostring(op2)
+    end,
+    __add = function(op1, op2)
+        return getnum(op1) + getnum(op2)
+    end,
+    __sub = function(op1, op2)
+        return getnum(op1) - getnum(op2)
+    end,
+    __mul = function(op1, op2)
+        return getnum(op1) * getnum(op2)
+    end,
+    __div = function(op1, op2)
+        return getnum(op1) / getnum(op2)
+    end,
+    __mod = function(op1, op2)
+        return getnum(op1) % getnum(op2)
+    end,
+    __pow = function(op1, op2)
+        return getnum(op1) ^ getnum(op2)
+    end,
+    __lt = function(op1, op2)
+        return getnum(op1) < getnum(op2)
+    end,
+    __eq = function(op1, op2)
+        return getnum(op1) == getnum(op2)
+    end,
+    __le = function(op1, op2)
+        return getnum(op1) <= getnum(op2)
+    end,
 }
 isNumber.__index = isNumber
 
 function OBJDEF:asNumber(item)
-
-   if getmetatable(item) == isNumber then
-      -- it's already a JSON number object.
-      return item
-   elseif type(item) == 'table' and type(item.S) == 'string' and type(item.N) == 'number' then
-      -- it's a number-object table that lost its metatable, so give it one
-      return setmetatable(item, isNumber)
-   else
-      -- the normal situation... given a number or a string representation of a number....
-      local holder = {
-         S = tostring(item), -- S is the representation of the number as a string, which remains precise
-         N = tonumber(item), -- N is the number as a Lua number.
-      }
-      return setmetatable(holder, isNumber)
-   end
+    if getmetatable(item) == isNumber then
+        -- it's already a JSON number object.
+        return item
+    elseif
+        type(item) == 'table'
+        and type(item.S) == 'string'
+        and type(item.N) == 'number'
+    then
+        -- it's a number-object table that lost its metatable, so give it one
+        return setmetatable(item, isNumber)
+    else
+        -- the normal situation... given a number or a string representation of a number....
+        local holder = {
+            S = tostring(item), -- S is the representation of the number as a string, which remains precise
+            N = tonumber(item), -- N is the number as a Lua number.
+        }
+        return setmetatable(holder, isNumber)
+    end
 end
 
 --
@@ -585,11 +620,11 @@ end
 -- to a string in most cases, but it's here to allow it to be forced when needed.
 --
 function OBJDEF:forceString(item)
-   if type(item) == 'table' and type(item.S) == 'string' then
-      return item.S
-   else
-      return tostring(item)
-   end
+    if type(item) == 'table' and type(item.S) == 'string' then
+        return item.S
+    else
+        return tostring(item)
+    end
 end
 
 --
@@ -597,625 +632,648 @@ end
 -- return the numeric version.
 --
 function OBJDEF:forceNumber(item)
-   if type(item) == 'table' and type(item.N) == 'number' then
-      return item.N
-   else
-      return tonumber(item)
-   end
+    if type(item) == 'table' and type(item.N) == 'number' then
+        return item.N
+    else
+        return tonumber(item)
+    end
 end
-   
 
 local function unicode_codepoint_as_utf8(codepoint)
-   --
-   -- codepoint is a number
-   --
-   if codepoint <= 127 then
-      return string.char(codepoint)
+    --
+    -- codepoint is a number
+    --
+    if codepoint <= 127 then
+        return string.char(codepoint)
+    elseif codepoint <= 2047 then
+        --
+        -- 110yyyxx 10xxxxxx         <-- useful notation from http://en.wikipedia.org/wiki/Utf8
+        --
+        local highpart = math.floor(codepoint / 0x40)
+        local lowpart = codepoint - (0x40 * highpart)
+        return string.char(0xC0 + highpart, 0x80 + lowpart)
+    elseif codepoint <= 65535 then
+        --
+        -- 1110yyyy 10yyyyxx 10xxxxxx
+        --
+        local highpart = math.floor(codepoint / 0x1000)
+        local remainder = codepoint - 0x1000 * highpart
+        local midpart = math.floor(remainder / 0x40)
+        local lowpart = remainder - 0x40 * midpart
 
-   elseif codepoint <= 2047 then
-      --
-      -- 110yyyxx 10xxxxxx         <-- useful notation from http://en.wikipedia.org/wiki/Utf8
-      --
-      local highpart = math.floor(codepoint / 0x40)
-      local lowpart  = codepoint - (0x40 * highpart)
-      return string.char(0xC0 + highpart,
-                         0x80 + lowpart)
+        highpart = 0xE0 + highpart
+        midpart = 0x80 + midpart
+        lowpart = 0x80 + lowpart
 
-   elseif codepoint <= 65535 then
-      --
-      -- 1110yyyy 10yyyyxx 10xxxxxx
-      --
-      local highpart  = math.floor(codepoint / 0x1000)
-      local remainder = codepoint - 0x1000 * highpart
-      local midpart   = math.floor(remainder / 0x40)
-      local lowpart   = remainder - 0x40 * midpart
+        --
+        -- Check for an invalid character (thanks Andy R. at Adobe).
+        -- See table 3.7, page 93, in http://www.unicode.org/versions/Unicode5.2.0/ch03.pdf#G28070
+        --
+        if
+            (highpart == 0xE0 and midpart < 0xA0)
+            or (highpart == 0xED and midpart > 0x9F)
+            or (highpart == 0xF0 and midpart < 0x90)
+            or (highpart == 0xF4 and midpart > 0x8F)
+        then
+            return '?'
+        else
+            return string.char(highpart, midpart, lowpart)
+        end
+    else
+        --
+        -- 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
+        --
+        local highpart = math.floor(codepoint / 0x40000)
+        local remainder = codepoint - 0x40000 * highpart
+        local midA = math.floor(remainder / 0x1000)
+        remainder = remainder - 0x1000 * midA
+        local midB = math.floor(remainder / 0x40)
+        local lowpart = remainder - 0x40 * midB
 
-      highpart = 0xE0 + highpart
-      midpart  = 0x80 + midpart
-      lowpart  = 0x80 + lowpart
-
-      --
-      -- Check for an invalid character (thanks Andy R. at Adobe).
-      -- See table 3.7, page 93, in http://www.unicode.org/versions/Unicode5.2.0/ch03.pdf#G28070
-      --
-      if ( highpart == 0xE0 and midpart < 0xA0 ) or
-         ( highpart == 0xED and midpart > 0x9F ) or
-         ( highpart == 0xF0 and midpart < 0x90 ) or
-         ( highpart == 0xF4 and midpart > 0x8F )
-      then
-         return "?"
-      else
-         return string.char(highpart,
-                            midpart,
-                            lowpart)
-      end
-
-   else
-      --
-      -- 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
-      --
-      local highpart  = math.floor(codepoint / 0x40000)
-      local remainder = codepoint - 0x40000 * highpart
-      local midA      = math.floor(remainder / 0x1000)
-      remainder       = remainder - 0x1000 * midA
-      local midB      = math.floor(remainder / 0x40)
-      local lowpart   = remainder - 0x40 * midB
-
-      return string.char(0xF0 + highpart,
-                         0x80 + midA,
-                         0x80 + midB,
-                         0x80 + lowpart)
-   end
+        return string.char(
+            0xF0 + highpart,
+            0x80 + midA,
+            0x80 + midB,
+            0x80 + lowpart
+        )
+    end
 end
 
 function OBJDEF:onDecodeError(message, text, location, etc)
-   if text then
-      if location then
-         message = string.format("%s at byte %d of: %s", message, location, text)
-      else
-         message = string.format("%s: %s", message, text)
-      end
-   end
+    if text then
+        if location then
+            message =
+                string.format('%s at byte %d of: %s', message, location, text)
+        else
+            message = string.format('%s: %s', message, text)
+        end
+    end
 
-   if etc ~= nil then
-      message = message .. " (" .. OBJDEF:encode(etc) .. ")"
-   end
+    if etc ~= nil then
+        message = message .. ' (' .. OBJDEF:encode(etc) .. ')'
+    end
 
-   if self.assert then
-      self.assert(false, message)
-   else
-      assert(false, message)
-   end
+    if self.assert then
+        self.assert(false, message)
+    else
+        assert(false, message)
+    end
 end
 
 function OBJDEF:onTrailingGarbage(json_text, location, parsed_value, etc)
-   return self:onDecodeError("trailing garbage", json_text, location, etc)
+    return self:onDecodeError('trailing garbage', json_text, location, etc)
 end
 
-OBJDEF.onDecodeOfNilError  = OBJDEF.onDecodeError
+OBJDEF.onDecodeOfNilError = OBJDEF.onDecodeError
 OBJDEF.onDecodeOfHTMLError = OBJDEF.onDecodeError
 
 function OBJDEF:onEncodeError(message, etc)
-   if etc ~= nil then
-      message = message .. " (" .. OBJDEF:encode(etc) .. ")"
-   end
+    if etc ~= nil then
+        message = message .. ' (' .. OBJDEF:encode(etc) .. ')'
+    end
 
-   if self.assert then
-      self.assert(false, message)
-   else
-      assert(false, message)
-   end
+    if self.assert then
+        self.assert(false, message)
+    else
+        assert(false, message)
+    end
 end
 
 local function grok_number(self, text, start, options)
-   --
-   -- Grab the integer part
-   --
-   local integer_part = text:match('^-?[1-9]%d*', start)
-                     or text:match("^-?0",        start)
+    --
+    -- Grab the integer part
+    --
+    local integer_part = text:match('^-?[1-9]%d*', start)
+        or text:match('^-?0', start)
 
-   if not integer_part then
-      self:onDecodeError("expected number", text, start, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
+    if not integer_part then
+        self:onDecodeError('expected number', text, start, options.etc)
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-   local i = start + integer_part:len()
+    local i = start + integer_part:len()
 
-   --
-   -- Grab an optional decimal part
-   --
-   local decimal_part = text:match('^%.%d+', i) or ""
+    --
+    -- Grab an optional decimal part
+    --
+    local decimal_part = text:match('^%.%d+', i) or ''
 
-   i = i + decimal_part:len()
+    i = i + decimal_part:len()
 
-   --
-   -- Grab an optional exponential part
-   --
-   local exponent_part = text:match('^[eE][-+]?%d+', i) or ""
+    --
+    -- Grab an optional exponential part
+    --
+    local exponent_part = text:match('^[eE][-+]?%d+', i) or ''
 
-   i = i + exponent_part:len()
+    i = i + exponent_part:len()
 
-   local full_number_text = integer_part .. decimal_part .. exponent_part
+    local full_number_text = integer_part .. decimal_part .. exponent_part
 
-   if options.decodeNumbersAsObjects then
-      return OBJDEF:asNumber(full_number_text), i
-   end
+    if options.decodeNumbersAsObjects then
+        return OBJDEF:asNumber(full_number_text), i
+    end
 
-   --
-   -- If we're told to stringify under certain conditions, so do.
-   -- We punt a bit when there's an exponent by just stringifying no matter what.
-   -- I suppose we should really look to see whether the exponent is actually big enough one
-   -- way or the other to trip stringification, but I'll be lazy about it until someone asks.
-   --
-   if (options.decodeIntegerStringificationLength
-       and
-      (integer_part:len() >= options.decodeIntegerStringificationLength or exponent_part:len() > 0))
+    --
+    -- If we're told to stringify under certain conditions, so do.
+    -- We punt a bit when there's an exponent by just stringifying no matter what.
+    -- I suppose we should really look to see whether the exponent is actually big enough one
+    -- way or the other to trip stringification, but I'll be lazy about it until someone asks.
+    --
+    if
+        (
+            options.decodeIntegerStringificationLength
+            and (
+                integer_part:len()
+                    >= options.decodeIntegerStringificationLength
+                or exponent_part:len() > 0
+            )
+        )
+        or (
+            options.decodeDecimalStringificationLength
+            and (
+                decimal_part:len()
+                    >= options.decodeDecimalStringificationLength
+                or exponent_part:len() > 0
+            )
+        )
+    then
+        return full_number_text, i -- this returns the exact string representation seen in the original JSON
+    end
 
-       or
+    local as_number = tonumber(full_number_text)
 
-      (options.decodeDecimalStringificationLength 
-       and
-       (decimal_part:len() >= options.decodeDecimalStringificationLength or exponent_part:len() > 0))
-   then
-      return full_number_text, i -- this returns the exact string representation seen in the original JSON
-   end
+    if not as_number then
+        self:onDecodeError('bad number', text, start, options.etc)
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-
-
-   local as_number = tonumber(full_number_text)
-
-   if not as_number then
-      self:onDecodeError("bad number", text, start, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
-
-   return as_number, i
+    return as_number, i
 end
 
-
 local function grok_string(self, text, start, options)
+    if text:sub(start, start) ~= '"' then
+        self:onDecodeError(
+            "expected string's opening quote",
+            text,
+            start,
+            options.etc
+        )
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text:sub(start,start) ~= '"' then
-      self:onDecodeError("expected string's opening quote", text, start, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
-
-   local i = start + 1 -- +1 to bypass the initial quote
-   local text_len = text:len()
-   local VALUE = ""
-   while i <= text_len do
-      local c = text:sub(i,i)
-      if c == '"' then
-         return VALUE, i + 1
-      end
-      if c ~= '\\' then
-         VALUE = VALUE .. c
-         i = i + 1
-      elseif text:match('^\\b', i) then
-         VALUE = VALUE .. "\b"
-         i = i + 2
-      elseif text:match('^\\f', i) then
-         VALUE = VALUE .. "\f"
-         i = i + 2
-      elseif text:match('^\\n', i) then
-         VALUE = VALUE .. "\n"
-         i = i + 2
-      elseif text:match('^\\r', i) then
-         VALUE = VALUE .. "\r"
-         i = i + 2
-      elseif text:match('^\\t', i) then
-         VALUE = VALUE .. "\t"
-         i = i + 2
-      else
-         local hex = text:match('^\\u([0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])', i)
-         if hex then
-            i = i + 6 -- bypass what we just read
-
-            -- We have a Unicode codepoint. It could be standalone, or if in the proper range and
-            -- followed by another in a specific range, it'll be a two-code surrogate pair.
-            local codepoint = tonumber(hex, 16)
-            if codepoint >= 0xD800 and codepoint <= 0xDBFF then
-               -- it's a hi surrogate... see whether we have a following low
-               local lo_surrogate = text:match('^\\u([dD][cdefCDEF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])', i)
-               if lo_surrogate then
-                  i = i + 6 -- bypass the low surrogate we just read
-                  codepoint = 0x2400 + (codepoint - 0xD800) * 0x400 + tonumber(lo_surrogate, 16)
-               else
-                  -- not a proper low, so we'll just leave the first codepoint as is and spit it out.
-               end
-            end
-            VALUE = VALUE .. unicode_codepoint_as_utf8(codepoint)
-
-         else
-
-            -- just pass through what's escaped
-            VALUE = VALUE .. text:match('^\\(.)', i)
+    local i = start + 1 -- +1 to bypass the initial quote
+    local text_len = text:len()
+    local VALUE = ''
+    while i <= text_len do
+        local c = text:sub(i, i)
+        if c == '"' then
+            return VALUE, i + 1
+        end
+        if c ~= '\\' then
+            VALUE = VALUE .. c
+            i = i + 1
+        elseif text:match('^\\b', i) then
+            VALUE = VALUE .. '\b'
             i = i + 2
-         end
-      end
-   end
+        elseif text:match('^\\f', i) then
+            VALUE = VALUE .. '\f'
+            i = i + 2
+        elseif text:match('^\\n', i) then
+            VALUE = VALUE .. '\n'
+            i = i + 2
+        elseif text:match('^\\r', i) then
+            VALUE = VALUE .. '\r'
+            i = i + 2
+        elseif text:match('^\\t', i) then
+            VALUE = VALUE .. '\t'
+            i = i + 2
+        else
+            local hex = text:match(
+                '^\\u([0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])',
+                i
+            )
+            if hex then
+                i = i + 6 -- bypass what we just read
 
-   self:onDecodeError("unclosed string", text, start, options.etc)
-   return nil, start -- in case the error method doesn't abort, return something sensible
+                -- We have a Unicode codepoint. It could be standalone, or if in the proper range and
+                -- followed by another in a specific range, it'll be a two-code surrogate pair.
+                local codepoint = tonumber(hex, 16)
+                if codepoint >= 0xD800 and codepoint <= 0xDBFF then
+                    -- it's a hi surrogate... see whether we have a following low
+                    local lo_surrogate = text:match(
+                        '^\\u([dD][cdefCDEF][0123456789aAbBcCdDeEfF][0123456789aAbBcCdDeEfF])',
+                        i
+                    )
+                    if lo_surrogate then
+                        i = i + 6 -- bypass the low surrogate we just read
+                        codepoint = 0x2400
+                            + (codepoint - 0xD800) * 0x400
+                            + tonumber(lo_surrogate, 16)
+                    else
+                        -- not a proper low, so we'll just leave the first codepoint as is and spit it out.
+                    end
+                end
+                VALUE = VALUE .. unicode_codepoint_as_utf8(codepoint)
+            else
+                -- just pass through what's escaped
+                VALUE = VALUE .. text:match('^\\(.)', i)
+                i = i + 2
+            end
+        end
+    end
+
+    self:onDecodeError('unclosed string', text, start, options.etc)
+    return nil, start -- in case the error method doesn't abort, return something sensible
 end
 
 local function skip_whitespace(text, start)
-
-   local _, match_end = text:find("^[ \n\r\t]+", start) -- [http://www.ietf.org/rfc/rfc4627.txt] Section 2
-   if match_end then
-      return match_end + 1
-   else
-      return start
-   end
+    local _, match_end = text:find('^[ \n\r\t]+', start) -- [http://www.ietf.org/rfc/rfc4627.txt] Section 2
+    if match_end then
+        return match_end + 1
+    else
+        return start
+    end
 end
 
 local grok_one -- assigned later
 
 local function grok_object(self, text, start, options)
+    if text:sub(start, start) ~= '{' then
+        self:onDecodeError("expected '{'", text, start, options.etc)
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text:sub(start,start) ~= '{' then
-      self:onDecodeError("expected '{'", text, start, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
+    local i = skip_whitespace(text, start + 1) -- +1 to skip the '{'
 
-   local i = skip_whitespace(text, start + 1) -- +1 to skip the '{'
+    local VALUE = self.strictTypes and self:newObject {} or {}
 
-   local VALUE = self.strictTypes and self:newObject { } or { }
+    if text:sub(i, i) == '}' then
+        return VALUE, i + 1
+    end
+    local text_len = text:len()
+    while i <= text_len do
+        local key, new_i = grok_string(self, text, i, options)
 
-   if text:sub(i,i) == '}' then
-      return VALUE, i + 1
-   end
-   local text_len = text:len()
-   while i <= text_len do
-      local key, new_i = grok_string(self, text, i, options)
+        i = skip_whitespace(text, new_i)
 
-      i = skip_whitespace(text, new_i)
+        if text:sub(i, i) ~= ':' then
+            self:onDecodeError('expected colon', text, i, options.etc)
+            return nil, i -- in case the error method doesn't abort, return something sensible
+        end
 
-      if text:sub(i, i) ~= ':' then
-         self:onDecodeError("expected colon", text, i, options.etc)
-         return nil, i -- in case the error method doesn't abort, return something sensible
-      end
+        i = skip_whitespace(text, i + 1)
 
-      i = skip_whitespace(text, i + 1)
+        local new_val, new_i = grok_one(self, text, i, options)
 
-      local new_val, new_i = grok_one(self, text, i, options)
+        VALUE[key] = new_val
 
-      VALUE[key] = new_val
+        --
+        -- Expect now either '}' to end things, or a ',' to allow us to continue.
+        --
+        i = skip_whitespace(text, new_i)
 
-      --
-      -- Expect now either '}' to end things, or a ',' to allow us to continue.
-      --
-      i = skip_whitespace(text, new_i)
+        local c = text:sub(i, i)
 
-      local c = text:sub(i,i)
+        if c == '}' then
+            return VALUE, i + 1
+        end
 
-      if c == '}' then
-         return VALUE, i + 1
-      end
+        if text:sub(i, i) ~= ',' then
+            self:onDecodeError("expected comma or '}'", text, i, options.etc)
+            return nil, i -- in case the error method doesn't abort, return something sensible
+        end
 
-      if text:sub(i, i) ~= ',' then
-         self:onDecodeError("expected comma or '}'", text, i, options.etc)
-         return nil, i -- in case the error method doesn't abort, return something sensible
-      end
+        i = skip_whitespace(text, i + 1)
+    end
 
-      i = skip_whitespace(text, i + 1)
-   end
-
-   self:onDecodeError("unclosed '{'", text, start, options.etc)
-   return nil, start -- in case the error method doesn't abort, return something sensible
+    self:onDecodeError("unclosed '{'", text, start, options.etc)
+    return nil, start -- in case the error method doesn't abort, return something sensible
 end
 
 local function grok_array(self, text, start, options)
-   if text:sub(start,start) ~= '[' then
-      self:onDecodeError("expected '['", text, start, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
+    if text:sub(start, start) ~= '[' then
+        self:onDecodeError("expected '['", text, start, options.etc)
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-   local i = skip_whitespace(text, start + 1) -- +1 to skip the '['
-   local VALUE = self.strictTypes and self:newArray { } or { }
-   if text:sub(i,i) == ']' then
-      return VALUE, i + 1
-   end
+    local i = skip_whitespace(text, start + 1) -- +1 to skip the '['
+    local VALUE = self.strictTypes and self:newArray {} or {}
+    if text:sub(i, i) == ']' then
+        return VALUE, i + 1
+    end
 
-   local VALUE_INDEX = 1
+    local VALUE_INDEX = 1
 
-   local text_len = text:len()
-   while i <= text_len do
-      local val, new_i = grok_one(self, text, i, options)
+    local text_len = text:len()
+    while i <= text_len do
+        local val, new_i = grok_one(self, text, i, options)
 
-      -- can't table.insert(VALUE, val) here because it's a no-op if val is nil
-      VALUE[VALUE_INDEX] = val
-      VALUE_INDEX = VALUE_INDEX + 1
+        -- can't table.insert(VALUE, val) here because it's a no-op if val is nil
+        VALUE[VALUE_INDEX] = val
+        VALUE_INDEX = VALUE_INDEX + 1
 
-      i = skip_whitespace(text, new_i)
+        i = skip_whitespace(text, new_i)
 
-      --
-      -- Expect now either ']' to end things, or a ',' to allow us to continue.
-      --
-      local c = text:sub(i,i)
-      if c == ']' then
-         return VALUE, i + 1
-      end
-      if text:sub(i, i) ~= ',' then
-         self:onDecodeError("expected comma or ']'", text, i, options.etc)
-         return nil, i -- in case the error method doesn't abort, return something sensible
-      end
-      i = skip_whitespace(text, i + 1)
-   end
-   self:onDecodeError("unclosed '['", text, start, options.etc)
-   return nil, i -- in case the error method doesn't abort, return something sensible
+        --
+        -- Expect now either ']' to end things, or a ',' to allow us to continue.
+        --
+        local c = text:sub(i, i)
+        if c == ']' then
+            return VALUE, i + 1
+        end
+        if text:sub(i, i) ~= ',' then
+            self:onDecodeError("expected comma or ']'", text, i, options.etc)
+            return nil, i -- in case the error method doesn't abort, return something sensible
+        end
+        i = skip_whitespace(text, i + 1)
+    end
+    self:onDecodeError("unclosed '['", text, start, options.etc)
+    return nil, i -- in case the error method doesn't abort, return something sensible
 end
 
-
 grok_one = function(self, text, start, options)
-   -- Skip any whitespace
-   start = skip_whitespace(text, start)
+    -- Skip any whitespace
+    start = skip_whitespace(text, start)
 
-   if start > text:len() then
-      self:onDecodeError("unexpected end of string", text, nil, options.etc)
-      return nil, start -- in case the error method doesn't abort, return something sensible
-   end
+    if start > text:len() then
+        self:onDecodeError('unexpected end of string', text, nil, options.etc)
+        return nil, start -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text:find('^"', start) then
-      return grok_string(self, text, start, options.etc)
-
-   elseif text:find('^[-0123456789 ]', start) then
-      return grok_number(self, text, start, options)
-
-   elseif text:find('^%{', start) then
-      return grok_object(self, text, start, options)
-
-   elseif text:find('^%[', start) then
-      return grok_array(self, text, start, options)
-
-   elseif text:find('^true', start) then
-      return true, start + 4
-
-   elseif text:find('^false', start) then
-      return false, start + 5
-
-   elseif text:find('^null', start) then
-      return nil, start + 4
-
-   else
-      self:onDecodeError("can't parse JSON", text, start, options.etc)
-      return nil, 1 -- in case the error method doesn't abort, return something sensible
-   end
+    if text:find('^"', start) then
+        return grok_string(self, text, start, options.etc)
+    elseif text:find('^[-0123456789 ]', start) then
+        return grok_number(self, text, start, options)
+    elseif text:find('^%{', start) then
+        return grok_object(self, text, start, options)
+    elseif text:find('^%[', start) then
+        return grok_array(self, text, start, options)
+    elseif text:find('^true', start) then
+        return true, start + 4
+    elseif text:find('^false', start) then
+        return false, start + 5
+    elseif text:find('^null', start) then
+        return nil, start + 4
+    else
+        self:onDecodeError("can't parse JSON", text, start, options.etc)
+        return nil, 1 -- in case the error method doesn't abort, return something sensible
+    end
 end
 
 function OBJDEF:decode(text, etc, options)
-   --
-   -- If the user didn't pass in a table of decode options, make an empty one.
-   --
-   if type(options) ~= 'table' then
-      options = {}
-   end
+    --
+    -- If the user didn't pass in a table of decode options, make an empty one.
+    --
+    if type(options) ~= 'table' then
+        options = {}
+    end
 
-   --
-   -- If they passed in an 'etc' argument, stuff it into the options.
-   -- (If not, any 'etc' field in the options they passed in remains to be used)
-   --
-   if etc ~= nil then
-      options.etc = etc
-   end
+    --
+    -- If they passed in an 'etc' argument, stuff it into the options.
+    -- (If not, any 'etc' field in the options they passed in remains to be used)
+    --
+    if etc ~= nil then
+        options.etc = etc
+    end
 
+    if type(self) ~= 'table' or self.__index ~= OBJDEF then
+        local error_message = 'JSON:decode must be called in method format'
+        OBJDEF:onDecodeError(error_message, nil, nil, options.etc)
+        return nil, error_message -- in case the error method doesn't abort, return something sensible
+    end
 
-   if type(self) ~= 'table' or self.__index ~= OBJDEF then
-      local error_message = "JSON:decode must be called in method format"
-      OBJDEF:onDecodeError(error_message, nil, nil, options.etc)
-      return nil, error_message -- in case the error method doesn't abort, return something sensible
-   end
+    if text == nil then
+        local error_message = 'nil passed to JSON:decode()'
+        self:onDecodeOfNilError(error_message, nil, nil, options.etc)
+        return nil, error_message -- in case the error method doesn't abort, return something sensible
+    elseif type(text) ~= 'string' then
+        local error_message = 'expected string argument to JSON:decode()'
+        self:onDecodeError(
+            string.format('%s, got %s', error_message, type(text)),
+            nil,
+            nil,
+            options.etc
+        )
+        return nil, error_message -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text == nil then
-      local error_message = "nil passed to JSON:decode()"
-      self:onDecodeOfNilError(error_message, nil, nil, options.etc)
-      return nil, error_message -- in case the error method doesn't abort, return something sensible
+    if text:match('^%s*$') then
+        -- an empty string is nothing, but not an error
+        return nil
+    end
 
-   elseif type(text) ~= 'string' then
-      local error_message = "expected string argument to JSON:decode()"
-      self:onDecodeError(string.format("%s, got %s", error_message, type(text)), nil, nil, options.etc)
-      return nil, error_message -- in case the error method doesn't abort, return something sensible
-   end
+    if text:match('^%s*<') then
+        -- Can't be JSON... we'll assume it's HTML
+        local error_message = 'HTML passed to JSON:decode()'
+        self:onDecodeOfHTMLError(error_message, text, nil, options.etc)
+        return nil, error_message -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text:match('^%s*$') then
-      -- an empty string is nothing, but not an error
-      return nil
-   end
+    --
+    -- Ensure that it's not UTF-32 or UTF-16.
+    -- Those are perfectly valid encodings for JSON (as per RFC 4627 section 3),
+    -- but this package can't handle them.
+    --
+    if
+        text:sub(1, 1):byte() == 0
+        or (text:len() >= 2 and text:sub(2, 2):byte() == 0)
+    then
+        local error_message = 'JSON package groks only UTF-8, sorry'
+        self:onDecodeError(error_message, text, nil, options.etc)
+        return nil, error_message -- in case the error method doesn't abort, return something sensible
+    end
 
-   if text:match('^%s*<') then
-      -- Can't be JSON... we'll assume it's HTML
-      local error_message = "HTML passed to JSON:decode()"
-      self:onDecodeOfHTMLError(error_message, text, nil, options.etc)
-      return nil, error_message -- in case the error method doesn't abort, return something sensible
-   end
+    --
+    -- apply global options
+    --
+    if options.decodeNumbersAsObjects == nil then
+        options.decodeNumbersAsObjects = self.decodeNumbersAsObjects
+    end
+    if options.decodeIntegerStringificationLength == nil then
+        options.decodeIntegerStringificationLength =
+            self.decodeIntegerStringificationLength
+    end
+    if options.decodeDecimalStringificationLength == nil then
+        options.decodeDecimalStringificationLength =
+            self.decodeDecimalStringificationLength
+    end
 
-   --
-   -- Ensure that it's not UTF-32 or UTF-16.
-   -- Those are perfectly valid encodings for JSON (as per RFC 4627 section 3),
-   -- but this package can't handle them.
-   --
-   if text:sub(1,1):byte() == 0 or (text:len() >= 2 and text:sub(2,2):byte() == 0) then
-      local error_message = "JSON package groks only UTF-8, sorry"
-      self:onDecodeError(error_message, text, nil, options.etc)
-      return nil, error_message -- in case the error method doesn't abort, return something sensible
-   end
+    --
+    -- Finally, go parse it
+    --
+    local success, value, next_i = pcall(grok_one, self, text, 1, options)
 
-   --
-   -- apply global options
-   --
-   if options.decodeNumbersAsObjects == nil then
-      options.decodeNumbersAsObjects = self.decodeNumbersAsObjects
-   end
-   if options.decodeIntegerStringificationLength == nil then
-      options.decodeIntegerStringificationLength = self.decodeIntegerStringificationLength
-   end
-   if options.decodeDecimalStringificationLength == nil then
-      options.decodeDecimalStringificationLength = self.decodeDecimalStringificationLength
-   end
+    if success then
+        local error_message = nil
+        if next_i ~= #text + 1 then
+            -- something's left over after we parsed the first thing.... whitespace is allowed.
+            next_i = skip_whitespace(text, next_i)
 
-   --
-   -- Finally, go parse it
-   --
-   local success, value, next_i = pcall(grok_one, self, text, 1, options)
-
-   if success then
-
-      local error_message = nil
-      if next_i ~= #text + 1 then
-         -- something's left over after we parsed the first thing.... whitespace is allowed.
-         next_i = skip_whitespace(text, next_i)
-
-         -- if we have something left over now, it's trailing garbage
-         if next_i ~= #text + 1 then
-            value, error_message = self:onTrailingGarbage(text, next_i, value, options.etc)
-         end
-      end
-      return value, error_message
-
-   else
-
-      -- If JSON:onDecodeError() didn't abort out of the pcall, we'll have received
-      -- the error message here as "value", so pass it along as an assert.
-      local error_message = value
-      if self.assert then
-         self.assert(false, error_message)
-      else
-         assert(false, error_message)
-      end
-      -- ...and if we're still here (because the assert didn't throw an error),
-      -- return a nil and throw the error message on as a second arg
-      return nil, error_message
-
-   end
+            -- if we have something left over now, it's trailing garbage
+            if next_i ~= #text + 1 then
+                value, error_message =
+                    self:onTrailingGarbage(text, next_i, value, options.etc)
+            end
+        end
+        return value, error_message
+    else
+        -- If JSON:onDecodeError() didn't abort out of the pcall, we'll have received
+        -- the error message here as "value", so pass it along as an assert.
+        local error_message = value
+        if self.assert then
+            self.assert(false, error_message)
+        else
+            assert(false, error_message)
+        end
+        -- ...and if we're still here (because the assert didn't throw an error),
+        -- return a nil and throw the error message on as a second arg
+        return nil, error_message
+    end
 end
 
 local function backslash_replacement_function(c)
-   if c == "\n" then
-      return "\\n"
-   elseif c == "\r" then
-      return "\\r"
-   elseif c == "\t" then
-      return "\\t"
-   elseif c == "\b" then
-      return "\\b"
-   elseif c == "\f" then
-      return "\\f"
-   elseif c == '"' then
-      return '\\"'
-   elseif c == '\\' then
-      return '\\\\'
-   else
-      return string.format("\\u%04x", c:byte())
-   end
+    if c == '\n' then
+        return '\\n'
+    elseif c == '\r' then
+        return '\\r'
+    elseif c == '\t' then
+        return '\\t'
+    elseif c == '\b' then
+        return '\\b'
+    elseif c == '\f' then
+        return '\\f'
+    elseif c == '"' then
+        return '\\"'
+    elseif c == '\\' then
+        return '\\\\'
+    else
+        return string.format('\\u%04x', c:byte())
+    end
 end
 
-local chars_to_be_escaped_in_JSON_string
-   = '['
-   ..    '"'    -- class sub-pattern to match a double quote
-   ..    '%\\'  -- class sub-pattern to match a backslash
-   ..    '%z'   -- class sub-pattern to match a null
-   ..    '\001' .. '-' .. '\031' -- class sub-pattern to match control characters
-   .. ']'
+local chars_to_be_escaped_in_JSON_string = '['
+    .. '"' -- class sub-pattern to match a double quote
+    .. '%\\' -- class sub-pattern to match a backslash
+    .. '%z' -- class sub-pattern to match a null
+    .. '\001'
+    .. '-'
+    .. '\031' -- class sub-pattern to match control characters
+    .. ']'
 
-
-local LINE_SEPARATOR_as_utf8      = unicode_codepoint_as_utf8(0x2028)
+local LINE_SEPARATOR_as_utf8 = unicode_codepoint_as_utf8(0x2028)
 local PARAGRAPH_SEPARATOR_as_utf8 = unicode_codepoint_as_utf8(0x2029)
 local function json_string_literal(value, options)
-   local newval = value:gsub(chars_to_be_escaped_in_JSON_string, backslash_replacement_function)
-   if options.stringsAreUtf8 then
-      --
-      -- This feels really ugly to just look into a string for the sequence of bytes that we know to be a particular utf8 character,
-      -- but utf8 was designed purposefully to make this kind of thing possible. Still, feels dirty.
-      -- I'd rather decode the byte stream into a character stream, but it's not technically needed so
-      -- not technically worth it.
-      --
-      newval = newval:gsub(LINE_SEPARATOR_as_utf8, '\\u2028'):gsub(PARAGRAPH_SEPARATOR_as_utf8,'\\u2029')
-   end
-   return '"' .. newval .. '"'
+    local newval = value:gsub(
+        chars_to_be_escaped_in_JSON_string,
+        backslash_replacement_function
+    )
+    if options.stringsAreUtf8 then
+        --
+        -- This feels really ugly to just look into a string for the sequence of bytes that we know to be a particular utf8 character,
+        -- but utf8 was designed purposefully to make this kind of thing possible. Still, feels dirty.
+        -- I'd rather decode the byte stream into a character stream, but it's not technically needed so
+        -- not technically worth it.
+        --
+        newval = newval
+            :gsub(LINE_SEPARATOR_as_utf8, '\\u2028')
+            :gsub(PARAGRAPH_SEPARATOR_as_utf8, '\\u2029')
+    end
+    return '"' .. newval .. '"'
 end
 
 local function object_or_array(self, T, etc)
-   --
-   -- We need to inspect all the keys... if there are any strings, we'll convert to a JSON
-   -- object. If there are only numbers, it's a JSON array.
-   --
-   -- If we'll be converting to a JSON object, we'll want to sort the keys so that the
-   -- end result is deterministic.
-   --
-   local string_keys = { }
-   local number_keys = { }
-   local number_keys_must_be_strings = false
-   local maximum_number_key
+    --
+    -- We need to inspect all the keys... if there are any strings, we'll convert to a JSON
+    -- object. If there are only numbers, it's a JSON array.
+    --
+    -- If we'll be converting to a JSON object, we'll want to sort the keys so that the
+    -- end result is deterministic.
+    --
+    local string_keys = {}
+    local number_keys = {}
+    local number_keys_must_be_strings = false
+    local maximum_number_key
 
-   for key in pairs(T) do
-      if type(key) == 'string' then
-         table.insert(string_keys, key)
-      elseif type(key) == 'number' then
-         table.insert(number_keys, key)
-         if key <= 0 or key >= math.huge then
-            number_keys_must_be_strings = true
-         elseif not maximum_number_key or key > maximum_number_key then
-            maximum_number_key = key
-         end
-      else
-         self:onEncodeError("can't encode table with a key of type " .. type(key), etc)
-      end
-   end
+    for key in pairs(T) do
+        if type(key) == 'string' then
+            table.insert(string_keys, key)
+        elseif type(key) == 'number' then
+            table.insert(number_keys, key)
+            if key <= 0 or key >= math.huge then
+                number_keys_must_be_strings = true
+            elseif not maximum_number_key or key > maximum_number_key then
+                maximum_number_key = key
+            end
+        else
+            self:onEncodeError(
+                "can't encode table with a key of type " .. type(key),
+                etc
+            )
+        end
+    end
 
-   if #string_keys == 0 and not number_keys_must_be_strings then
-      --
-      -- An empty table, or a numeric-only array
-      --
-      if #number_keys > 0 then
-         return nil, maximum_number_key -- an array
-      elseif tostring(T) == "JSON array" then
-         return nil
-      elseif tostring(T) == "JSON object" then
-         return { }
-      else
-         -- have to guess, so we'll pick array, since empty arrays are likely more common than empty objects
-         return nil
-      end
-   end
+    if #string_keys == 0 and not number_keys_must_be_strings then
+        --
+        -- An empty table, or a numeric-only array
+        --
+        if #number_keys > 0 then
+            return nil, maximum_number_key -- an array
+        elseif tostring(T) == 'JSON array' then
+            return nil
+        elseif tostring(T) == 'JSON object' then
+            return {}
+        else
+            -- have to guess, so we'll pick array, since empty arrays are likely more common than empty objects
+            return nil
+        end
+    end
 
-   table.sort(string_keys)
+    table.sort(string_keys)
 
-   local map
-   if #number_keys > 0 then
-      --
-      -- If we're here then we have either mixed string/number keys, or numbers inappropriate for a JSON array
-      -- It's not ideal, but we'll turn the numbers into strings so that we can at least create a JSON object.
-      --
+    local map
+    if #number_keys > 0 then
+        --
+        -- If we're here then we have either mixed string/number keys, or numbers inappropriate for a JSON array
+        -- It's not ideal, but we'll turn the numbers into strings so that we can at least create a JSON object.
+        --
 
-      if self.noKeyConversion then
-         self:onEncodeError("a table with both numeric and string keys could be an object or array; aborting", etc)
-      end
+        if self.noKeyConversion then
+            self:onEncodeError(
+                'a table with both numeric and string keys could be an object or array; aborting',
+                etc
+            )
+        end
 
-      --
-      -- Have to make a shallow copy of the source table so we can remap the numeric keys to be strings
-      --
-      map = { }
-      for key, val in pairs(T) do
-         map[key] = val
-      end
+        --
+        -- Have to make a shallow copy of the source table so we can remap the numeric keys to be strings
+        --
+        map = {}
+        for key, val in pairs(T) do
+            map[key] = val
+        end
 
-      table.sort(number_keys)
+        table.sort(number_keys)
 
-      --
-      -- Throw numeric keys in there as strings
-      --
-      for _, number_key in ipairs(number_keys) do
-         local string_key = tostring(number_key)
-         if map[string_key] == nil then
-            table.insert(string_keys , string_key)
-            map[string_key] = T[number_key]
-         else
-            self:onEncodeError("conflict converting table with mixed-type keys into a JSON object: key " .. number_key .. " exists both as a string and a number.", etc)
-         end
-      end
-   end
+        --
+        -- Throw numeric keys in there as strings
+        --
+        for _, number_key in ipairs(number_keys) do
+            local string_key = tostring(number_key)
+            if map[string_key] == nil then
+                table.insert(string_keys, string_key)
+                map[string_key] = T[number_key]
+            else
+                self:onEncodeError(
+                    'conflict converting table with mixed-type keys into a JSON object: key '
+                        .. number_key
+                        .. ' exists both as a string and a number.',
+                    etc
+                )
+            end
+        end
+    end
 
-   return string_keys, nil, map
+    return string_keys, nil, map
 end
 
 --
@@ -1240,203 +1298,264 @@ end
 --
 local encode_value -- must predeclare because it calls itself
 function encode_value(self, value, parents, etc, options, indent, for_key)
+    --
+    -- keys in a JSON object can never be null, so we don't even consider options.null when converting a key value
+    --
+    if
+        value == nil
+        or (not for_key and options and options.null and value == options.null)
+    then
+        return 'null'
+    elseif type(value) == 'string' then
+        return json_string_literal(value, options)
+    elseif type(value) == 'number' then
+        if value ~= value then
+            --
+            -- NaN (Not a Number).
+            -- JSON has no NaN, so we have to fudge the best we can. This should really be a package option.
+            --
+            return 'null'
+        elseif value >= math.huge then
+            --
+            -- Positive infinity. JSON has no INF, so we have to fudge the best we can. This should
+            -- really be a package option. Note: at least with some implementations, positive infinity
+            -- is both ">= math.huge" and "<= -math.huge", which makes no sense but that's how it is.
+            -- Negative infinity is properly "<= -math.huge". So, we must be sure to check the ">="
+            -- case first.
+            --
+            return '1e+9999'
+        elseif value <= -math.huge then
+            --
+            -- Negative infinity.
+            -- JSON has no INF, so we have to fudge the best we can. This should really be a package option.
+            --
+            return '-1e+9999'
+        else
+            return tostring(value)
+        end
+    elseif type(value) == 'boolean' then
+        return tostring(value)
+    elseif type(value) ~= 'table' then
+        self:onEncodeError("can't convert " .. type(value) .. ' to JSON', etc)
+    elseif getmetatable(value) == isNumber then
+        return tostring(value)
+    else
+        --
+        -- A table to be converted to either a JSON object or array.
+        --
+        local T = value
 
-   --
-   -- keys in a JSON object can never be null, so we don't even consider options.null when converting a key value
-   --
-   if value == nil or (not for_key and options and options.null and value == options.null) then
-      return 'null'
+        if type(options) ~= 'table' then
+            options = {}
+        end
+        if type(indent) ~= 'string' then
+            indent = ''
+        end
 
-   elseif type(value) == 'string' then
-      return json_string_literal(value, options)
+        if parents[T] then
+            self:onEncodeError(
+                'table ' .. tostring(T) .. ' is a child of itself',
+                etc
+            )
+        else
+            parents[T] = true
+        end
 
-   elseif type(value) == 'number' then
-      if value ~= value then
-         --
-         -- NaN (Not a Number).
-         -- JSON has no NaN, so we have to fudge the best we can. This should really be a package option.
-         --
-         return "null"
-      elseif value >= math.huge then
-         --
-         -- Positive infinity. JSON has no INF, so we have to fudge the best we can. This should
-         -- really be a package option. Note: at least with some implementations, positive infinity
-         -- is both ">= math.huge" and "<= -math.huge", which makes no sense but that's how it is.
-         -- Negative infinity is properly "<= -math.huge". So, we must be sure to check the ">="
-         -- case first.
-         --
-         return "1e+9999"
-      elseif value <= -math.huge then
-         --
-         -- Negative infinity.
-         -- JSON has no INF, so we have to fudge the best we can. This should really be a package option.
-         --
-         return "-1e+9999"
-      else
-         return tostring(value)
-      end
+        local result_value
 
-   elseif type(value) == 'boolean' then
-      return tostring(value)
+        local object_keys, maximum_number_key, map =
+            object_or_array(self, T, etc)
+        if maximum_number_key then
+            --
+            -- An array...
+            --
+            local ITEMS = {}
+            local key_indent = indent .. tostring(options.indent or '')
+            for i = 1, maximum_number_key do
+                if not options.array_newline then
+                    table.insert(
+                        ITEMS,
+                        encode_value(self, T[i], parents, etc, options, indent)
+                    )
+                else
+                    table.insert(
+                        ITEMS,
+                        encode_value(
+                            self,
+                            T[i],
+                            parents,
+                            etc,
+                            options,
+                            key_indent
+                        )
+                    )
+                end
+            end
 
-   elseif type(value) ~= 'table' then
-      self:onEncodeError("can't convert " .. type(value) .. " to JSON", etc)
-
-   elseif getmetatable(value) == isNumber then
-      return tostring(value)
-   else
-      --
-      -- A table to be converted to either a JSON object or array.
-      --
-      local T = value
-
-      if type(options) ~= 'table' then
-         options = {}
-      end
-      if type(indent) ~= 'string' then
-         indent = ""
-      end
-
-      if parents[T] then
-         self:onEncodeError("table " .. tostring(T) .. " is a child of itself", etc)
-      else
-         parents[T] = true
-      end
-
-      local result_value
-
-      local object_keys, maximum_number_key, map = object_or_array(self, T, etc)
-      if maximum_number_key then
-         --
-         -- An array...
-         --
-         local ITEMS = { }
-         local key_indent = indent .. tostring(options.indent or "")
-         for i = 1, maximum_number_key do
-            if not options.array_newline then
-               table.insert(ITEMS, encode_value(self, T[i], parents, etc, options, indent))
+            if options.pretty then
+                if not options.array_newline then
+                    result_value = '[ ' .. table.concat(ITEMS, ', ') .. ' ]'
+                else
+                    result_value = '[\n'
+                        .. key_indent
+                        .. table.concat(ITEMS, ',\n' .. key_indent)
+                        .. '\n'
+                        .. indent
+                        .. ']'
+                end
             else
-               table.insert(ITEMS, encode_value(self, T[i], parents, etc, options, key_indent))
+                result_value = '[' .. table.concat(ITEMS, ',') .. ']'
             end
-         end
+        elseif object_keys then
+            --
+            -- An object
+            --
+            local TT = map or T
 
-         if options.pretty then
-            if not options.array_newline then
-               result_value = "[ " .. table.concat(ITEMS, ", ") .. " ]"
+            if options.pretty then
+                local KEYS = {}
+                local max_key_length = 0
+                for _, key in ipairs(object_keys) do
+                    local encoded = encode_value(
+                        self,
+                        tostring(key),
+                        parents,
+                        etc,
+                        options,
+                        indent,
+                        true
+                    )
+                    if options.align_keys then
+                        max_key_length = math.max(max_key_length, #encoded)
+                    end
+                    table.insert(KEYS, encoded)
+                end
+                local key_indent = indent .. tostring(options.indent or '')
+                local subtable_indent = key_indent
+                    .. string.rep(' ', max_key_length)
+                    .. (options.align_keys and '  ' or '')
+                local FORMAT = '%s%'
+                    .. string.format('%d', max_key_length)
+                    .. 's: %s'
+
+                local COMBINED_PARTS = {}
+                for i, key in ipairs(object_keys) do
+                    local encoded_val = encode_value(
+                        self,
+                        TT[key],
+                        parents,
+                        etc,
+                        options,
+                        subtable_indent
+                    )
+                    table.insert(
+                        COMBINED_PARTS,
+                        string.format(FORMAT, key_indent, KEYS[i], encoded_val)
+                    )
+                end
+                result_value = '{\n'
+                    .. table.concat(COMBINED_PARTS, ',\n')
+                    .. '\n'
+                    .. indent
+                    .. '}'
             else
-               result_value =  "[\n"  ..  key_indent .. table.concat(ITEMS, ",\n" .. key_indent) .. "\n" ..  indent .. "]"
+                local PARTS = {}
+                for _, key in ipairs(object_keys) do
+                    local encoded_val = encode_value(
+                        self,
+                        TT[key],
+                        parents,
+                        etc,
+                        options,
+                        indent
+                    )
+                    local encoded_key = encode_value(
+                        self,
+                        tostring(key),
+                        parents,
+                        etc,
+                        options,
+                        indent,
+                        true
+                    )
+                    table.insert(
+                        PARTS,
+                        string.format('%s:%s', encoded_key, encoded_val)
+                    )
+                end
+                result_value = '{' .. table.concat(PARTS, ',') .. '}'
             end
-         else
-            result_value = "["  .. table.concat(ITEMS, ",")  .. "]"
-         end
+        else
+            --
+            -- An empty array/object... we'll treat it as an array, though it should really be an option
+            --
+            result_value = '[]'
+        end
 
-      elseif object_keys then
-         --
-         -- An object
-         --
-         local TT = map or T
-
-         if options.pretty then
-
-            local KEYS = { }
-            local max_key_length = 0
-            for _, key in ipairs(object_keys) do
-               local encoded = encode_value(self, tostring(key), parents, etc, options, indent, true)
-               if options.align_keys then
-                  max_key_length = math.max(max_key_length, #encoded)
-               end
-               table.insert(KEYS, encoded)
-            end
-            local key_indent = indent .. tostring(options.indent or "")
-            local subtable_indent = key_indent .. string.rep(" ", max_key_length) .. (options.align_keys and "  " or "")
-            local FORMAT = "%s%" .. string.format("%d", max_key_length) .. "s: %s"
-
-            local COMBINED_PARTS = { }
-            for i, key in ipairs(object_keys) do
-               local encoded_val = encode_value(self, TT[key], parents, etc, options, subtable_indent)
-               table.insert(COMBINED_PARTS, string.format(FORMAT, key_indent, KEYS[i], encoded_val))
-            end
-            result_value = "{\n" .. table.concat(COMBINED_PARTS, ",\n") .. "\n" .. indent .. "}"
-
-         else
-
-            local PARTS = { }
-            for _, key in ipairs(object_keys) do
-               local encoded_val = encode_value(self, TT[key],       parents, etc, options, indent)
-               local encoded_key = encode_value(self, tostring(key), parents, etc, options, indent, true)
-               table.insert(PARTS, string.format("%s:%s", encoded_key, encoded_val))
-            end
-            result_value = "{" .. table.concat(PARTS, ",") .. "}"
-
-         end
-      else
-         --
-         -- An empty array/object... we'll treat it as an array, though it should really be an option
-         --
-         result_value = "[]"
-      end
-
-      parents[T] = false
-      return result_value
-   end
+        parents[T] = false
+        return result_value
+    end
 end
 
 local function top_level_encode(self, value, etc, options)
-   local val = encode_value(self, value, {}, etc, options)
-   if val == nil then
-      --PRIVATE("may need to revert to the previous public verison if I can't figure out what the guy wanted")
-      return val
-   else
-      return val
-   end
+    local val = encode_value(self, value, {}, etc, options)
+    if val == nil then
+        --PRIVATE("may need to revert to the previous public verison if I can't figure out what the guy wanted")
+        return val
+    else
+        return val
+    end
 end
 
 function OBJDEF:encode(value, etc, options)
-   if type(self) ~= 'table' or self.__index ~= OBJDEF then
-      OBJDEF:onEncodeError("JSON:encode must be called in method format", etc)
-   end
+    if type(self) ~= 'table' or self.__index ~= OBJDEF then
+        OBJDEF:onEncodeError('JSON:encode must be called in method format', etc)
+    end
 
-   --
-   -- If the user didn't pass in a table of decode options, make an empty one.
-   --
-   if type(options) ~= 'table' then
-      options = {}
-   end
+    --
+    -- If the user didn't pass in a table of decode options, make an empty one.
+    --
+    if type(options) ~= 'table' then
+        options = {}
+    end
 
-   return top_level_encode(self, value, etc, options)
+    return top_level_encode(self, value, etc, options)
 end
 
 function OBJDEF:encode_pretty(value, etc, options)
-   if type(self) ~= 'table' or self.__index ~= OBJDEF then
-      OBJDEF:onEncodeError("JSON:encode_pretty must be called in method format", etc)
-   end
+    if type(self) ~= 'table' or self.__index ~= OBJDEF then
+        OBJDEF:onEncodeError(
+            'JSON:encode_pretty must be called in method format',
+            etc
+        )
+    end
 
-   --
-   -- If the user didn't pass in a table of decode options, use the default pretty ones
-   --
-   if type(options) ~= 'table' then
-      options = default_pretty_options
-   end
+    --
+    -- If the user didn't pass in a table of decode options, use the default pretty ones
+    --
+    if type(options) ~= 'table' then
+        options = default_pretty_options
+    end
 
-   return top_level_encode(self, value, etc, options)
+    return top_level_encode(self, value, etc, options)
 end
 
 function OBJDEF.__tostring()
-   return "JSON encode/decode package"
+    return 'JSON encode/decode package'
 end
 
 OBJDEF.__index = OBJDEF
 
 function OBJDEF:new(args)
-   local new = { }
+    local new = {}
 
-   if args then
-      for key, val in pairs(args) do
-         new[key] = val
-      end
-   end
+    if args then
+        for key, val in pairs(args) do
+            new[key] = val
+        end
+    end
 
-   return setmetatable(new, OBJDEF)
+    return setmetatable(new, OBJDEF)
 end
 
 return OBJDEF:new()
@@ -1459,7 +1578,7 @@ return OBJDEF:new()
 --
 
 --   20160916.19   Fixed the isNumber.__index assignment (thanks to Jack Taylor)
---   
+--
 --   20160730.18   Added JSON:forceString() and JSON:forceNumber()
 --
 --   20160728.17   Added concatenation to the metatable for JSON:asNumber()
@@ -1527,7 +1646,7 @@ return OBJDEF:new()
 --
 --                 To maintain the prior throw-an-error semantics, set
 --                      JSON.noKeyConversion = true
---                 
+--
 --   20131004.7    Release under a Creative Commons CC-BY license, which I should have done from day one, sorry.
 --
 --   20130120.6    Comment update: added a link to the specific page on my blog where this code can


### PR DESCRIPTION
Creates an interactive screen for submitting your name + score to the leaderboard API. Additionally, it adds a `config.json` file where the leaderboard API URL can be configured. A [JSON parsing library](https://github.com/tiye/json-lua) is vendored because luarocks sucks. The screen is not yet wired up to launch when the game ends.

Design decisions:
- max name length 32 (front end only)
- share the same background color as the main menu
- reusable text input component

For testing: `ZPJ_START_SCREEN=leaderboardsubmit love .`

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/1a49132d-3844-452a-90a6-aee6df55c0a9" />
