### PR TITLE
feat: added bouncing

### DIFF
--- a/camera.lua
+++ b/camera.lua
@@ -72,8 +72,8 @@ function Camera.changeVelocityX(changeX)
 
     Camera.velocityX = newX
 
-    print('Cam Vel X:', Camera.velocityX)
-    print('newX:', newX)
+    -- print('Cam Vel X:', Camera.velocityX)
+    -- print('newX:', newX)
 end
 
 function Camera.getVelocityX()

--- a/player.lua
+++ b/player.lua
@@ -135,6 +135,14 @@ function Player.getSpeedBasedGravity(velocityX, maxVelocityY)
     return HIGH_GRAVITY + (LOW_GRAVITY - HIGH_GRAVITY) * curve
 end
 
+function Player.calculateBounce(velY, maxVelX)
+    local velX = Camera.getVelocityX()
+    local horizontalFactor = 0.5 * (math.abs(velX) / maxVelX)
+    local bounceStrength = 100
+    print('bounce:', -velY * bounceStrength * horizontalFactor)
+    return -velY * bounceStrength * horizontalFactor
+end
+
 -- Updates Player's Y position
 --- @param dt number deltaTime
 function Player.updatePosY(dt)
@@ -146,9 +154,16 @@ function Player.updatePosY(dt)
         Player.posY = (Player.dim / 2)
         Player.velocityY = 0
     end
+
+    -- This section is where we do logic for hitting the bottom
     if Player.posY > (designHeight - (Player.dim / 2)) then
         Player.posY = (designHeight - (Player.dim / 2))
-        Player.velocityY = 0
+        -- print('Hit the bottom: velY:', Player.velocityY)
+        Player.velocityY = Player.calculateBounce(
+            Player.velocityY,
+            Player.maxVelocityX
+        )
+        print('Player VelY:', Player.velocityY)
     end
 
     -- Slowly rotates player

--- a/player.lua
+++ b/player.lua
@@ -139,7 +139,7 @@ function Player.calculateBounce(velY, maxVelX)
     local velX = Camera.getVelocityX()
     local horizontalFactor = 0.5 * (math.abs(velX) / maxVelX)
     local bounceStrength = 100
-    print('bounce:', -velY * bounceStrength * horizontalFactor)
+    -- print('bounce:', -velY * bounceStrength * horizontalFactor)
     return -velY * bounceStrength * horizontalFactor
 end
 
@@ -159,11 +159,9 @@ function Player.updatePosY(dt)
     if Player.posY > (designHeight - (Player.dim / 2)) then
         Player.posY = (designHeight - (Player.dim / 2))
         -- print('Hit the bottom: velY:', Player.velocityY)
-        Player.velocityY = Player.calculateBounce(
-            Player.velocityY,
-            Player.maxVelocityX
-        )
-        print('Player VelY:', Player.velocityY)
+        Player.velocityY =
+            Player.calculateBounce(Player.velocityY, Player.maxVelocityX)
+        -- print('Player VelY:', Player.velocityY)
     end
 
     -- Slowly rotates player

--- a/spec/bounce_spec.lua
+++ b/spec/bounce_spec.lua
@@ -1,0 +1,55 @@
+local Player = require('player')
+local Camera = require('camera')
+
+describe('Bounce_Test_Suite', function()
+    local tolerance = 0.001
+
+    local function approxEqual(actual, expected)
+        return math.abs(actual - expected) < tolerance
+    end
+
+    describe('calculateBounce', function()
+        it('calculates bounce with positive velocity and positive camera velocity', function()
+            Camera.velocityX = 100
+            local bounce = Player.calculateBounce(-50, 300)
+            local expected = 50 * 100 * (0.5 * math.abs(100) / 300)
+            assert.is_true(approxEqual(bounce, expected))
+        end)
+
+        it('calculates bounce with negative camera velocity', function()
+            Camera.velocityX = -100
+            local bounce = Player.calculateBounce(-50, 300)
+            local expected = 50 * 100 * (0.5 * math.abs(-100) / 300)
+            assert.is_true(approxEqual(bounce, expected))
+        end)
+
+        it('calculates bounce with zero camera velocity', function()
+            Camera.velocityX = 0
+            local bounce = Player.calculateBounce(-50, 300)
+            local expected = 0
+            assert.is_true(approxEqual(bounce, expected))
+        end)
+
+        it('calculates bounce with different maxVelX values', function()
+            Camera.velocityX = 150
+            local bounce1 = Player.calculateBounce(-50, 300)
+            local bounce2 = Player.calculateBounce(-50, 150)
+            local expected1 = 50 * 100 * (0.5 * math.abs(150) / 300)
+            local expected2 = 50 * 100 * (0.5 * math.abs(150) / 150)
+            assert.is_true(approxEqual(bounce1, expected1))
+            assert.is_true(approxEqual(bounce2, expected2))
+            assert.is_true(bounce1 ~= bounce2)
+        end)
+
+        it('calculates bounce with different velY values', function()
+            Camera.velocityX = 100
+            local bounce1 = Player.calculateBounce(-30, 300)
+            local bounce2 = Player.calculateBounce(-60, 300)
+            local expected1 = 30 * 100 * (0.5 * math.abs(100) / 300)
+            local expected2 = 60 * 100 * (0.5 * math.abs(100) / 300)
+            assert.is_true(approxEqual(bounce1, expected1))
+            assert.is_true(approxEqual(bounce2, expected2))
+            assert.is_true(bounce2 > bounce1)
+        end)
+    end)
+end)

--- a/spec/bounce_spec.lua
+++ b/spec/bounce_spec.lua
@@ -2,6 +2,8 @@ local Player = require('player')
 local Camera = require('camera')
 
 describe('Bounce_Test_Suite', function()
+    -- A lot of the velocity are float values
+    -- just had to add a tolerance to compare float values
     local tolerance = 0.001
 
     local function approxEqual(actual, expected)
@@ -9,12 +11,15 @@ describe('Bounce_Test_Suite', function()
     end
 
     describe('calculateBounce', function()
-        it('calculates bounce with positive velocity and positive camera velocity', function()
-            Camera.velocityX = 100
-            local bounce = Player.calculateBounce(-50, 300)
-            local expected = 50 * 100 * (0.5 * math.abs(100) / 300)
-            assert.is_true(approxEqual(bounce, expected))
-        end)
+        it(
+            'calculates bounce with positive velocity and positive camera velocity',
+            function()
+                Camera.velocityX = 100
+                local bounce = Player.calculateBounce(-50, 300)
+                local expected = 50 * 100 * (0.5 * math.abs(100) / 300)
+                assert.is_true(approxEqual(bounce, expected))
+            end
+        )
 
         it('calculates bounce with negative camera velocity', function()
             Camera.velocityX = -100
@@ -53,3 +58,4 @@ describe('Bounce_Test_Suite', function()
         end)
     end)
 end)
+


### PR DESCRIPTION
added bouncing that is relative to the players x and y velocity. The bouncing will not occur as the player is close to 0 in the x direction. Again, this functions relies on "magic" numbers to calculate the strength of the bounce. These will inevitably have to be changed as time moves on and as more input is given.